### PR TITLE
Refactor test runner and fix sudo and groups

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -18,5 +18,7 @@ jobs:
       run: sudo apt-get install -y shellcheck
     - name: Run lint
       run: make lint
+    - name: Prepare test image
+      run: make test-image
     - name: Run tests
       run: make test

--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,5 @@
 tests/*.log
 .test-image
+.gh-users
+.ssh-key-cache
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,38 @@
-# base image for running tests
-# - preinstalled packages for test speed
+# Base image for running tests.
+#
+# We are using docker as way to test scripts desinged to run inside a regular
+# ubuntu VM. We could user lxd or similar instead, but docker runs OOTB in GH
+# actions.So we install ubuntu-server on top of the ubuntu:20.04 image, and
+# this gets us much closer to a regular VM image.
+#
+# Importantly, we run system as PID 1, like a regular VM. This allows our
+# scripts to install and run systemd services of their own.
+# 
+# Note: this means we need to run this image with some specific options:
+# 
+#   --cap-add SYS_ADMIN \
+#   --tmpfs /tmp --tmpfs /run --tmpfs /run/lock \
+#   -v /sys/fs/cgroup:/sys/fs/cgroup:ro \
+#
+# We also pre-install our packages, so that tests run faster.
 FROM ubuntu:20.04
-ENV DEBIAN_FRONTEND="noninteractive"
-RUN apt-get update && apt-get upgrade -y
+
+ENV container docker
+ENV LC_ALL C
+ENV DEBIAN_FRONTEND noninteractive
+
+RUN sed -i 's/# deb/deb/g' /etc/apt/sources.list
+
+RUN apt-get update && \
+    apt-get upgrade -y && \
+    apt-get install -y ubuntu-server
+
+VOLUME [ "/sys/fs/cgroup" ]
+
+CMD ["/lib/systemd/systemd"]
+
+# preinstall our packages for speed when running tests
 COPY packages.txt /tmp/packages.txt
-RUN cat /tmp/packages.txt | sed 's/^#.*//' | xargs apt-get install -y
+RUN sed 's/^#.*//' /tmp/packages.txt | xargs apt-get install -y && \
+    apt-get clean && \
+    rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/*

--- a/Dockerfile
+++ b/Dockerfile
@@ -17,9 +17,9 @@
 # We also pre-install our packages, so that tests run faster.
 FROM ubuntu:20.04
 
-ENV container docker
-ENV LC_ALL C
-ENV DEBIAN_FRONTEND noninteractive
+ENV container=docker
+ENV LC_ALL=C
+ENV DEBIAN_FRONTEND=noninteractive
 
 RUN sed -i 's/# deb/deb/g' /etc/apt/sources.list
 

--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,7 @@
 TESTS ?= $(shell ls tests/*.sh)
-# can override in environment
-RATELIMITED ?= false
 TEST_IMAGE=backend-server-test
+export TEST=true
+
 
 # disable default rules
 .SUFFIXES:
@@ -12,20 +12,37 @@ lint:
 	shellcheck */*.sh
 
 
+# list of all github users mentioned in the repo
+.gh-users: developers */researchers */reviewers
+	cat $^ | sort | uniq | grep -v '^#' > $@
+
+
+# fetch and cache gh keys for users, so we can avoid ratelimits when testing locally
+.ssh-key-cache: .gh-users
+	mkdir -p .ssh-key-cache
+	for u in $$(cat .gh-users); do ssh-import-id gh:$$u -o $@/$$u; done
+
+
+# proxy file to track image needing to be rebuilt
+.test-image: packages.txt Dockerfile
+	$(MAKE) test-image
+
+
 .PHONY: test-image
 test-image:
 	docker build . -t $(TEST_IMAGE) && touch .test-image
 
 
-# file proxy for when the image was last built
-.test-image: packages.txt Dockerfile
-	$(MAKE) test-image
-
-
+# run all tests
 .PHONY: test
 test: $(TESTS)
 
 
+# run specific test
 .PHONY: $(TESTS)
-$(TESTS): .test-image
-	cat $@ | docker run -i --rm -e SHELLOPTS=xtrace -e RATELIMITED=$(RATELIMITED) -v $$PWD:/tests -w /tests $(TEST_IMAGE) bash -euo pipefail
+$(TESTS): .test-image | .ssh-key-cache
+	./run-in-docker.sh $@
+
+
+clean:
+	rm -rf .gh-users .ssh-key-cache

--- a/Makefile
+++ b/Makefile
@@ -19,7 +19,7 @@ lint:
 
 # fetch and cache gh keys for users, so we can avoid ratelimits when testing locally
 .ssh-key-cache: .gh-users
-	mkdir -p .ssh-key-cache
+	mkdir -p $@
 	for u in $$(cat .gh-users); do ssh-import-id gh:$$u -o $@/$$u; done
 
 

--- a/etc/developers-sudo-access
+++ b/etc/developers-sudo-access
@@ -1,0 +1,1 @@
+%developers  ALL=(ALL:ALL) NOPASSWD: ALL

--- a/packages.txt
+++ b/packages.txt
@@ -4,8 +4,9 @@ unattended-upgrades
 docker.io
 ssh-import-id
 # debug tools
+vim
 tree
 silversearcher-ag
-sysstat
+#temp disabled sysstat
 iotop
 tcpdump

--- a/run-in-docker.sh
+++ b/run-in-docker.sh
@@ -1,0 +1,34 @@
+#!/bin/bash
+# Run an ubuntu docker "VM", then run the passed command inside it.  The
+# container is deleted when this script exits.
+#
+# Run with DEBUG=1 to run a shell inside the container after running your
+# script
+# 
+# Note: you may need to first build the test image before you can manually run
+# this script:
+#     
+#     make test-image
+#
+set -euo pipefail
+TEST_IMAGE=backend-server-test
+DEBUG=${DEBUG:-}
+
+# Launch a container running systemd
+CONTAINER="$(
+    docker run -d --rm \
+               --cap-add SYS_ADMIN --tmpfs /tmp --tmpfs /run --tmpfs /run/lock -v /sys/fs/cgroup:/sys/fs/cgroup:ro \
+               -v "$PWD:/tests" "$TEST_IMAGE"
+)"
+
+trap 'docker rm -f $CONTAINER >/dev/null' EXIT
+
+test -n "$DEBUG" && set +e  # DEBUG mode: do not exit if the test errors
+
+# run test script
+docker exec -i -e SHELLOPTS=xtrace -e TEST=true -w /tests "$CONTAINER" "$@"
+
+if test -n "$DEBUG"; then
+    echo "Running bash inside container (container will be deleted on exit)"
+    docker exec -it -e TEST=true -w /tests "$CONTAINER" bash
+fi

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -15,3 +15,5 @@ for group in developers researchers reviewers; do
         groupadd $group
     fi
 done
+
+cp etc/developers-sudo-access /etc/sudoers.d

--- a/scripts/update-ssh.sh
+++ b/scripts/update-ssh.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 set -euo pipefail
-
 user=$1
+TEST=${TEST:-}
 
 # generate clean authorized_keys file from current sources list. This
 # will drop keys that have been removed from this repo or from github
@@ -12,9 +12,17 @@ if test -f "keys/$user"; then
     cat "keys/$user" > "$tmp"
 fi
 
-# import current gh keys on top
-test "$RATELIMITED" == "true" || ssh-import-id "gh:$user" --output "$tmp"
+# workaround for gh ratelimits when runing tests locally
+cache=.ssh-key-cache/$user
+# if we have a cached file, and TEST is set, then use cache
+if test -f "$cache" -a -n "${TEST}"; then
+    cat "$cache" >> "$tmp"
+else
+    # add current gh keys into $tmp
+    ssh-import-id "gh:$user" --output "$tmp"
+fi
 
 # replace current authorized_keys
 mkdir -p "/home/$user/.ssh"
 mv "$tmp" "/home/$user/.ssh/authorized_keys"
+chown -R "$user:$user" "/home/$user/.ssh/"

--- a/scripts/update-users.sh
+++ b/scripts/update-users.sh
@@ -43,14 +43,20 @@ add_group() {
     done < "$file"
 }
 
-# developers is mandatory
-add_group "$developers" developers researchers reviewers
+# developers is mandatory. They get docker and sudo access
+add_group "$developers" developers researchers reviewers docker sudo
 
-# other groups depend on backend
+# Note: the following groups are optional, depends on how the users will
+# authenticate with the specific backend
+
+# optional researchers (level 3) group. They got docker to be able manually run stuff if needed.
 if test -f "$researchers"; then
-    add_group "$researchers" researchers reviewers
+    add_group "$researchers" researchers reviewers docker
 fi
 
+# optional reviewers (level 4) group. Minimial permissions. Long term goal is
+# no local accounts needed for this group, but early EMIS backend set up
+# requires them.
 if test -f "$reviewers"; then
     add_group "$reviewers" reviewers
 fi


### PR DESCRIPTION
 - install ubuntu-server, and run with systemd
 - allows us to run systemd servers, and is closed to VM
 - workaround github ratelimits in testing by caching
 - add researchers to docker group
 - add developers to sudo and docker group
 - give developers sudoless password access