### PR TITLE
Initial EMIS backend deployment

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -11,7 +11,7 @@ export TEST=true
 
 .PHONY: lint
 lint:
-	shellcheck */*.sh
+	shellcheck */*.sh jobrunner/bashrc
 
 
 # list of all github users mentioned in the repo

--- a/emis-backend/backend.env
+++ b/emis-backend/backend.env
@@ -1,9 +1,6 @@
-# Non-secret confiugration specific to the TPP backend
+# Non-secret confiugration specific to the EMIS backend
 
 BACKEND=emis
-
-# Database in which we can create temporary tables
-TEMP_DATABASE_NAME=
 
 # Default if unset is cpus-1
 MAX_WORKERS=

--- a/emis-backend/manage.sh
+++ b/emis-backend/manage.sh
@@ -4,3 +4,19 @@ set -euo pipefail
 ./scripts/install.sh
 ./scripts/update-users.sh developers emis-backend/researchers emis-backend/reviewers
 ./scripts/jobrunner.sh emis-backend
+
+for f in /srv/jobrunner/environ/*.env; do
+    . $f
+done
+
+
+if test -z "${PRESTO_TLS_KEY_PATH:-}"; then
+    echo "WARNING: PRESTO_TLS_KEY_PATH env var not defined"
+else
+    test -e "${PRESTO_TLS_KEY_PATH:-}" ||  echo "WARNING: PRESTO_TLS_KEY_PATH=$PRESTO_TLS_KEY_PATH does not exist"
+fi
+if test -z "${PRESTO_TLS_CERT_PATH:-}"; then
+    echo "WARNING: PRESTO_TLS_CERT_PATH env var not defined"
+else
+    test -e "${PRESTO_TLS_CERT_PATH:-}" ||  echo "WARNING: PRESTO_TLS_CERT_PATH=$PRESTO_TLS_CERT_PATH does not exist"
+fi

--- a/emis-backend/manage.sh
+++ b/emis-backend/manage.sh
@@ -6,7 +6,8 @@ set -euo pipefail
 ./scripts/jobrunner.sh emis-backend
 
 for f in /srv/jobrunner/environ/*.env; do
-    . $f
+    # shellcheck disable=SC1090
+    . "$f"
 done
 
 

--- a/jobrunner/bashrc
+++ b/jobrunner/bashrc
@@ -1,8 +1,9 @@
+#!/bin/bash
 # load config into this shell so we can just run stuff
 set -a
 # shellcheck disable=SC1090
 for f in /srv/jobrunner/environ/*.env; do
-    . $f
+    . "$f"
 done
 set +a
 cat << EOF

--- a/jobrunner/bashrc
+++ b/jobrunner/bashrc
@@ -1,7 +1,9 @@
 # load config into this shell so we can just run stuff
 set -a
 # shellcheck disable=SC1090
-. /srv/jobrunner/environ/*.env
+for f in /srv/jobrunner/environ/*.env; do
+    . $f
+done
 set +a
 cat << EOF
 You have logged into the shared jobrunner account for managing the jobrunner service.

--- a/jobrunner/secrets-template.env
+++ b/jobrunner/secrets-template.env
@@ -16,5 +16,10 @@ SLICE_DATABASE_URL=
 # The full database
 FULL_DATABASE_URL=
 
+# For EMIS backends
+PRESTO_TLS_CERT_PATH=
+PRESTO_TLS_KEY_PATH=
+EMIS_ORGANISATION_HASH=
+
 # License key for stata as a string, for running stata images
 STATA_LICENSE=

--- a/scripts/jobrunner.sh
+++ b/scripts/jobrunner.sh
@@ -56,8 +56,9 @@ test -f "$local_env" || echo "# add local overrides here" > "$local_env"
 # load config
 set -a
 # shellcheck disable=SC1090
-for f in $DIR/environ/*.env; do
-    . $f
+for f in "$DIR"/environ/*.env; do
+    # shellcheck disable=1090
+    . "$f"
 done
 set +a;
 

--- a/scripts/update-ssh.sh
+++ b/scripts/update-ssh.sh
@@ -19,7 +19,7 @@ if test -f "$cache" -a -n "${TEST}"; then
     cat "$cache" >> "$tmp"
 else
     # add current gh keys into $tmp
-    ssh-import-id "gh:$user" --output "$tmp"
+    curl -s https://github.com/$user.keys -o "$tmp"
 fi
 
 # replace current authorized_keys

--- a/scripts/update-ssh.sh
+++ b/scripts/update-ssh.sh
@@ -19,7 +19,7 @@ if test -f "$cache" -a -n "${TEST}"; then
     cat "$cache" >> "$tmp"
 else
     # add current gh keys into $tmp
-    curl -s "https://github.com/$user.keys" -o "$tmp"
+    curl -s "https://github.com/$user.keys" >> "$tmp"
 fi
 
 # replace current authorized_keys

--- a/scripts/update-ssh.sh
+++ b/scripts/update-ssh.sh
@@ -19,7 +19,7 @@ if test -f "$cache" -a -n "${TEST}"; then
     cat "$cache" >> "$tmp"
 else
     # add current gh keys into $tmp
-    curl -s https://github.com/$user.keys -o "$tmp"
+    curl -s "https://github.com/$user.keys" -o "$tmp"
 fi
 
 # replace current authorized_keys


### PR DESCRIPTION
 - we don't have api.github.com access, so switch from ssh-import-id to
 curl.
 - manage a /srv/jobserver/secret dir for the certs
 - add EMIS variables to the secrets-template.env
 - fix a bug in the sourcing of multiple files