### PR TITLE
Add missing bash strict mode commands in tests.

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -25,7 +25,7 @@ RUN sed -i 's/# deb/deb/g' /etc/apt/sources.list
 
 RUN apt-get update && \
     apt-get upgrade -y && \
-    apt-get install -y ubuntu-server sudo
+    apt-get install -y ubuntu-server sudo python3 python3-pip python3-venv
 
 VOLUME [ "/sys/fs/cgroup" ]
 

--- a/tests/emis.sh
+++ b/tests/emis.sh
@@ -1,8 +1,8 @@
 #!/bin/bash
+set -euo pipefail
 ./emis-backend/manage.sh
 #run again to check for idempotency
 ./emis-backend/manage.sh
 
 # Some assertions
-set -e
 grep -q SimonDavy@OPENCORONA ~bloodearnest/.ssh/authorized_keys

--- a/tests/install.sh
+++ b/tests/install.sh
@@ -1,4 +1,5 @@
 #!/bin/bash
+set -euo pipefail
 # Test install scripts
 ./scripts/install.sh
 # run again to test idempotency

--- a/tests/jobrunner.sh
+++ b/tests/jobrunner.sh
@@ -1,4 +1,5 @@
 #!/bin/bash
+set -euo pipefail
 ./scripts/install.sh
 ./scripts/jobrunner.sh tpp-backend
 

--- a/tests/tpp.sh
+++ b/tests/tpp.sh
@@ -1,4 +1,5 @@
 #!/bin/bash
+set -euo pipefail
 ./tpp-backend/manage.sh
 # run again to check for idempotency
 ./tpp-backend/manage.sh


### PR DESCRIPTION
For some reason they were missing.

Also, fix a resulting failure that required python3 in the test image.