### PR TITLE
Fix test docker image to be more ubuntu server-like

### DIFF
--- a/packages.txt
+++ b/packages.txt
@@ -3,6 +3,7 @@ unattended-upgrades
 # core dependencies
 docker.io
 ssh-import-id
+python3-pip
 # debug tools
 vim
 tree

--- a/run-in-docker.sh
+++ b/run-in-docker.sh
@@ -16,6 +16,12 @@ LOG=$SCRIPT.log
 TEST_IMAGE=backend-server-test
 DEBUG=${DEBUG:-}
 
+if test -n "$DEBUG"; then
+    LOG=/dev/stdout
+else
+    LOG=$SCRIPT.log
+fi
+
 # Launch a container running systemd
 CONTAINER="$(
     docker run -d --rm \
@@ -35,21 +41,22 @@ set -e
 if test $success -eq 0; then
     echo "SUCCESS"
 else
-    echo "FAILED - output logged to $LOG"
-    echo "### $1 ###"
-    if test -x "${CI:-}"; then
-        echo "..."
-        tail -20 "$LOG"
-    else
-        cat "$LOG"
+    echo "FAILED"
+    if test -f "$LOG"; then
+        echo "### $1 ###"
+        if test -x "${CI:-}"; then
+            echo "..."
+            tail -20 "$LOG"
+        else
+            cat "$LOG"
+        fi
+        echo "### $1 ###"
     fi
-    echo "### $1 ###"
 fi
 
 if test -n "$DEBUG"; then
-    cat "$LOG"
     echo "Running bash inside container (container will be deleted on exit)"
     docker exec -it -e TEST=true -w /tests "$CONTAINER" bash
-else
-    exit $success
 fi
+
+exit $success


### PR DESCRIPTION
Also, update test runner to log to console in debug runs.

A couple of extra details:

 - switching from rolling our own systemd setup to using [jrei/systemd-ubuntu](https://hub.docker.com/r/jrei/systemd-ubuntu).
 - rather than cleaning up apt-get files, we just leave them, as it speeds up tests runs, and the test image is always local, so the space savings don't buy us much.