### PR TITLE
Harden configuration after pen-test results

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -11,7 +11,7 @@ export TEST=true
 
 .PHONY: lint
 lint:
-	shellcheck */*.sh jobrunner/bashrc
+	shellcheck -x */*.sh jobrunner/bashrc
 
 
 # list of all github users mentioned in the repo

--- a/etc/developers-sudo-access
+++ b/etc/developers-sudo-access
@@ -1,1 +1,0 @@
-%developers  ALL=(ALL:ALL) NOPASSWD: ALL

--- a/etc/opensafely/profile
+++ b/etc/opensafely/profile
@@ -1,0 +1,3 @@
+# 15min shell timeout, will close SSH connections.
+readonly TMOUT=900
+export TMOUT

--- a/etc/opensafely/pwquality.conf
+++ b/etc/opensafely/pwquality.conf
@@ -1,0 +1,5 @@
+# Opensafely password config
+
+minlen = 14
+# must have at least one digit, uppercase, lowercase, special
+minclass = 4

--- a/etc/opensafely/ssh-banner
+++ b/etc/opensafely/ssh-banner
@@ -1,0 +1,1 @@
+This is an OpenSAFELY backend

--- a/etc/opensafely/ssh.conf
+++ b/etc/opensafely/ssh.conf
@@ -1,0 +1,22 @@
+# hardening overrides to defaults
+
+PermitRootLogin no
+
+# SSH public keys only
+PasswordAuthentication no
+
+# 4 means the 2nd/3rd/4th attempts are log
+MaxAuthTries 4
+
+# No need, and possibly security hole
+X11Forwarding no
+
+# after 300s, explicitly ask the client if we're still alive
+ClientAliveInterval 300
+
+# DOS protection
+MaxStartups 10:30:60
+
+Banner /etc/opensafely/ssh-banner
+
+MACs hmac-sha2-256-etm@openssh.com,hmac-sha2-512-etm@openssh.com,hmac-sha2-512,hmac-sha2-256

--- a/etc/opensafely/sudoers
+++ b/etc/opensafely/sudoers
@@ -1,0 +1,10 @@
+# Limit forking long running processes
+Defaults use_pty
+
+# Log sudo acess
+Defaults logfile=/var/log/sudo.log
+
+# developers group has sudo access
+%developers  ALL=(ALL:ALL) ALL
+
+

--- a/packages.txt
+++ b/packages.txt
@@ -1,6 +1,7 @@
 # security
 gpg
 unattended-upgrades
+libpam-pwquality
 # core dependencies
 docker.io
 python3-pip

--- a/run-in-docker.sh
+++ b/run-in-docker.sh
@@ -15,6 +15,10 @@ SCRIPT=$1
 LOG=$SCRIPT.log
 TEST_IMAGE=backend-server-test
 DEBUG=${DEBUG:-}
+TRACE=${TRACE:-}
+DOCKER_SHELLOPTS=
+
+test -n "$TRACE" && DOCKER_SHELLOPTS=xtrace
 
 if test -n "$DEBUG"; then
     LOG=/dev/stdout
@@ -34,7 +38,7 @@ trap 'docker rm -f $CONTAINER >/dev/null' EXIT
 # run test script
 set +e # we handle the error manually
 echo -n "Running $1 in container..."
-docker exec -i -e SHELLOPTS=xtrace -e TEST=true -w /tests "$CONTAINER" "$SCRIPT" > "$LOG" 2>&1
+docker exec -i -e SHELLOPTS=${DOCKER_SHELLOPTS} -e TEST=true -w /tests "$CONTAINER" "$SCRIPT" > "$LOG" 2>&1
 success=$?
 
 set -e

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -22,4 +22,20 @@ for group in developers researchers reviewers; do
     fi
 done
 
-cp etc/developers-sudo-access /etc/sudoers.d
+
+# system configurations
+
+# disable broken-by-default rsync service
+systemctl disable rsync
+
+# copy our files
+cp -a --no-preserve ownership etc/opensafely /etc/
+chmod 0640 /etc/opensafely/*
+
+ln -sf /etc/opensafely/profile /etc/profile.d/opensafely.sh
+ln -sf /etc/opensafely/sudoers /etc/sudoers.d/opensafely
+ln -sf /etc/opensafely/ssh.conf /etc/ssh/sshd_config.d/99-opensafely.conf
+
+grep -q "^UMASK.*027" /etc/login.defs || sed -i 's/^UMASK.*$/UMASK 027/' /etc/login.defs
+
+systemctl reload ssh

--- a/scripts/update-users.sh
+++ b/scripts/update-users.sh
@@ -17,6 +17,10 @@ add_user() {
     else
         echo "Adding user $user"
         useradd "$user" --create-home --shell /bin/bash
+        # delete and expire their password, forcing reset on first ssh login
+        passwd -de "$user"
+        # ensure home not world readable
+        chmod -R o-rwx "/home/$user"
     fi
 
     for group in $groups; do

--- a/tests/install.sh
+++ b/tests/install.sh
@@ -2,6 +2,54 @@
 set -euo pipefail
 # Test install scripts
 ./scripts/install.sh
+./scripts/update-users.sh developers
+
 # run again to test idempotency
 ./scripts/install.sh
 
+. tests/utils
+
+# test sshd config
+sshd -T > /tmp/ssh-config
+strip-comments etc/opensafely/ssh.conf | while read -r line; do
+    assert "ssh: $line is set" grep -qi "$line" /tmp/ssh-config
+done
+
+# test /etc/profile
+(
+set +u
+. /etc/profile
+set -u
+assert "env var: TMOUT is set" test "$TMOUT" == "900"
+)
+
+
+# create test user for password checking
+useradd testpwuser --create-home --shell /bin/bash
+
+# helper function because chpasswd does not error correctly
+test-password() {
+    ! echo "testpwuser:$1" | chpasswd 2>&1 | grep -q "BAD PASSWORD" 
+}
+
+assert-fails "password: bad password rejected" test-password simple
+assert "password: password accepted " test-password 'a$#sdad0822daf0flASD'
+
+# test sudo
+useradd testsudouser --create-home --shell /bin/bash
+
+assert-fails "sudo: not in developers group" su - testsudouser -c 'sudo ls /root'
+
+usermod -a -G developers testsudouser
+# sudo config works
+assert-fails "sudo: no password set" su - testsudouser -c 'sudo ls /root'
+
+password='V4al1d-p4##0rd'
+echo "testsudouser:$password" | chpasswd
+echo "$password" | assert "sudo: password sudo works" su - testsudouser -c 'sudo -S ls /root'
+
+actual_user=$(head -1 developers)
+assert "users: directory permissions" test "$(stat -c '%a' "/home/$actual_user")" == "750"
+
+# shellcheck disable=SC2154
+exit "$success"

--- a/tests/utils
+++ b/tests/utils
@@ -1,0 +1,36 @@
+#!/bin/bash
+
+# final success or failure
+success=0
+
+# strip comments and blank lines from a file
+strip-comments() {
+    sed -e '/^\s*$/d' -e '/^\s*#.*$/d' $1
+}
+
+assert() {
+  local desc=$1
+  local log=$(mktemp)
+  shift;
+  if "$@" >"$log" 2>&1; then
+    echo "PASS: $desc"
+  else
+    echo "FAIL: $desc"
+    cat "$log"
+    success=1
+  fi
+}
+
+assert-fails() {
+  local desc=$1
+  local log=$(mktemp)
+  shift;
+  if "$@" >"$log" 2>&1; then
+    echo "FAIL: $desc"
+    cat "$log"
+    success=1
+  else
+    echo "PASS: $desc"
+  fi
+}
+


### PR DESCRIPTION
Specifically, this addresses the following findings from the pen-test
report:

2.1  - password is now required for sudo, password set on first login
2.6  - sudo configured to log properly
2.11 - rynsc service disabled
2.22 - shell timeout configured
2.23 - ssh configuration hardened per recommendations
2.26 - home directories no longer world readable