### PR TITLE
Add basic NHSD backend configuration

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -35,7 +35,7 @@ keys/testuser:
 
 .PHONY: test-image
 test-image:
-	docker build . -t $(TEST_IMAGE) && touch .test-image
+	docker build . $(ARGS) -t $(TEST_IMAGE) && touch .test-image
 
 
 # run all tests

--- a/core-packages.txt
+++ b/core-packages.txt
@@ -1,0 +1,8 @@
+# these are the core dependencies need to run a backend
+docker.io
+python3
+python3-pip
+python3-distutils
+tzdata
+ca-certificates
+

--- a/nhsd-backend/README.md
+++ b/nhsd-backend/README.md
@@ -1,0 +1,11 @@
+# NHSD Backend
+
+This is the configuration for the NSHD DAE hosted backend.
+
+This is different from other backends in that the system configuration, users
+and ssh keys are managed by NHSD. The mangage.sh script for this backend
+therefore just manages the job-runner setup.
+
+
+We do not therefore use the default install script, and instead directly
+install the packages core-packages.txt, and then just the job-runner itself.

--- a/nhsd-backend/README.md
+++ b/nhsd-backend/README.md
@@ -1,6 +1,7 @@
 # NHSD Backend
 
-This is the configuration for the NSHD DAE hosted backend.
+This is the configuration for the NSHD Data Access Environment (DAE) hosted
+backend.
 
 This is different from other backends in that the system configuration, users
 and ssh keys are managed by NHSD. The mangage.sh script for this backend

--- a/nhsd-backend/backend.env
+++ b/nhsd-backend/backend.env
@@ -1,0 +1,6 @@
+# Initially we are using the dummy backend
+BACKEND=expectations
+#BACKEND=nshd
+
+# Default if unset is cpus-1
+MAX_WORKERS=

--- a/nhsd-backend/manage.sh
+++ b/nhsd-backend/manage.sh
@@ -1,0 +1,10 @@
+#!/bin/bash
+set -euo pipefail
+
+# install/update the core requirements
+apt-get update
+sed 's/^#.*//' core-packages.txt | xargs apt-get install -y
+
+# setup job runner
+./scripts/jobrunner.sh nhsd-backend
+

--- a/packages.txt
+++ b/packages.txt
@@ -1,10 +1,8 @@
+# these are additional packages that we use when managing our own backends
 # security
 gpg
 unattended-upgrades
 libpam-pwquality
-# core dependencies
-docker.io
-python3-pip
 # debug tools
 vim
 tree

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -9,6 +9,7 @@ set +u
 sed 's/^#.*//' purge-packages.txt | xargs apt-get purge -y
 apt-get update
 apt-get upgrade -y
+sed 's/^#.*//' core-packages.txt | xargs apt-get install -y
 sed 's/^#.*//' packages.txt | xargs apt-get install -y
 apt-get autoremove -y
 

--- a/scripts/jobrunner.sh
+++ b/scripts/jobrunner.sh
@@ -68,8 +68,8 @@ for output_dir in "$HIGH_PRIVACY_STORAGE_BASE" "$MEDIUM_PRIVACY_STORAGE_BASE"; d
     # only group read access, no world access
     find "$output_dir" -type f -exec chmod 640 {} +
 done
-chown -R jobrunner:researchers "$HIGH_PRIVACY_STORAGE_BASE"
-chown -R jobrunner:reviewers "$MEDIUM_PRIVACY_STORAGE_BASE"
+chown -R jobrunner:jobrunner "$HIGH_PRIVACY_STORAGE_BASE"
+chown -R jobrunner:jobrunner "$MEDIUM_PRIVACY_STORAGE_BASE"
 
 # set up some nice helpers for when we su into the shared jobrunner user
 cp jobrunner/bashrc $DIR/bashrc

--- a/system-requirements.md
+++ b/system-requirements.md
@@ -21,8 +21,10 @@ The explicit list can be found in [core-packages.txt](core-packages.txt).
 The is currently a single service, `job-runner`, which is installed in /srv/jobrunner.
 A `jobrunner` user is created to run it, and appropriate systemd unit file is installed.
 
-This service does not listen on any port, but regularly polls out to the
-OpenSAFELY platform, for new jobs or publishing job status or results.
+This service does not listen on any port, but regularly initiates requests to the
+OpenSAFELY platform, to request new jobs and to publish job statuses.  It also
+downloads github repositories containing the jobs to execute and the Docker
+images used to run them, via the OpenSAFELY proxies (see below).
 
 
 ## Network Requirements

--- a/system-requirements.md
+++ b/system-requirements.md
@@ -1,0 +1,42 @@
+# OpenSAFELY Backend System Requirements
+
+## Base System
+
+The OpenSAFELY backend is designed and tested to run on an Ubuntu 20.04 LTS VM.
+
+This should have access to an appropriate Ubuntu archive mirror, and be
+configured to apply security updates automatically.
+
+
+## Dependencies
+
+The required packages are `python3` (which is python 3.8 in 20.04) and
+`docker.io` (the Ubuntu packaged version of docker).
+
+The explicit list can be found in [core-packages.txt](core-packages.txt).
+
+
+## Services
+
+The is currently a single service, `job-runner`, which is installed in /srv/jobrunner.
+A `jobrunner` user is created to run it, and appropriate systemd unit file is installed.
+
+This service does not listen on any port, but regularly polls out to the
+OpenSAFELY platform, for new jobs or publishing job status or results.
+
+
+## Network Requirements
+
+An OpenSAFELY backend requires egress to 157.245.31.108 on port 443.
+
+If routing via a HTTPS proxy, then the following domains are required (all accessible via that IP):
+
+    jobs.opensafely.org
+    docker-proxy.opensafely.org
+    github-proxy.opensafely.org
+
+
+Note: the 2 proxy domains proxy HTTPS requests through to `ghcr.io` and
+`github.com` respectively. They restrict access to the OpenSAFELY and
+opensafely-core Github organisations only, and are read only.
+


### PR DESCRIPTION
 - split out core dependencies from others
 - drop use of researchers group for file perms
 - add explicit system requirements docs