### PR TITLE
use new execution API by default in all backends

### DIFF
--- a/jobrunner/defaults.env
+++ b/jobrunner/defaults.env
@@ -23,3 +23,4 @@ JOB_LOOP_INTERVAL=5.0
 # release-hatch config
 RELEASE_HOST=http://localhost:8001
 WORKSPACES=/workspaces
+EXECUTION_API=true

--- a/tests/test-backend.sh
+++ b/tests/test-backend.sh
@@ -42,7 +42,7 @@ do
 done
 EOF
 
-tout 30s bash "$script" || { journalctl -u jobrunner; exit 1; }
+tout 60s bash "$script" || { journalctl -u jobrunner; exit 1; }
 
 # run release-hatch tests
 ./tests/check-release-hatch


### PR DESCRIPTION
Interestingly, this increased the run time for the test-backends
functional test, and I need to extend the timeout.
