### PR TITLE
make release-hatch run over TLS by default.

### DIFF
--- a/jobrunner/defaults.env
+++ b/jobrunner/defaults.env
@@ -21,6 +21,6 @@ JOB_LOOP_INTERVAL=5.0
 
 
 # release-hatch config
-RELEASE_HOST=http://localhost:8001
+RELEASE_HOST=https://localhost
 WORKSPACES=/workspaces
 EXECUTION_API=true

--- a/release-hatch/README.md
+++ b/release-hatch/README.md
@@ -9,8 +9,16 @@ normal docker tools or via docker-compose.
 
 # Configuration
 
-release-hatch shares the same configuration as jobrunner, which lives in
-`/srv/jobrunner/environ/*.env`.
+release-hatch shares the same configuration as jobrunner, which currently lives
+in `/srv/jobrunner/environ/*.env`. In particular, it uses `JOB_SERVER_TOKEN` to
+sign and validate requests, and it uses `RELEASE_HOST` to know what domain it
+should be serving files from.
+
+The only additional configuration is the TLS cert/key files. These live at
+`~jobrunner/release-hatch/certs/release-hatch.{crt,key}`, and are used by the
+docker container to configure TLS. 
+
+The default install will generate self-signed certifcates, but these can replaced.
 
 # Useful commands
 

--- a/release-hatch/docker-compose.yaml
+++ b/release-hatch/docker-compose.yaml
@@ -3,7 +3,7 @@
 # it supports.
 version: "3.7"
 services:
-  release-hatch:
+  release-hatch: &service
     # image: ghcr.io/opensafely-core/release-hatch:${BACKEND}
     image: docker-proxy.opensafely.org/opensafely-core/release-hatch:latest
     container_name: release-hatch
@@ -11,12 +11,34 @@ services:
     restart: unless-stopped
     network_mode: bridge
     ports:
-      - "8001:8001"
+      - "443:8001"
     user: 10000:10000
     env_file:
       - /srv/jobrunner/environ/01_defaults.env
       - /srv/jobrunner/environ/02_secrets.env
       - /srv/jobrunner/environ/03_backend.env
       - /srv/jobrunner/environ/04_local.env
+    environment:
+      UVICORN_SSL_CERTFILE: /certs/release-hatch.crt
+      UVICORN_SSL_KEYFILE: /certs/release-hatch.key
     volumes:
       - /srv/medium_privacy/workspaces:/workspaces
+      - ./certs:/certs
+
+  # Run a function test against the running release-hatch service
+  # This runs a functional test shipped with release-hatch.
+  release-hatch-test:
+
+    # The version of docker-compose in Ubuntu 20.04 (1.25) does not support
+    # `extends`, so we use YAML anchor tricks to create a test service that
+    # extends the base service. This statement copies all the keys from the
+    # anchor &service above
+    <<: *service
+    # We need to run from the host's network, so we can access release-hatch
+    # via the proper DNS/port settings, because the validation for
+    # release-hatch requires the configured DNS/ports to match.
+    network_mode: host
+    # assume self-signed cert
+    environment:
+      REQUESTS_CA_BUNDLE: /certs/release-hatch.crt
+    command: python hatch/client.py test

--- a/release-hatch/install.sh
+++ b/release-hatch/install.sh
@@ -20,7 +20,7 @@ if ! test -e $SSL_KEY -a -e $SSL_CERT; then
 
     # generate a self signed certificate
     openssl req -x509 -newkey ed25519 -keyout $SSL_KEY -out $SSL_CERT -sha256 -days 365 -nodes \
-	    -subj "/C=GB/L=Lehi/O=OpenSAFELY/CN=$HOSTNAME/emailAddress=tech@opensafely.org" \
+	    -subj "/C=GB/O=OpenSAFELY/CN=$HOSTNAME/emailAddress=tech@opensafely.org" \
 	    -addext "subjectAltName = DNS:$HOSTNAME"
 
     # ensure self signed is trusted by this machine

--- a/release-hatch/install.sh
+++ b/release-hatch/install.sh
@@ -2,7 +2,33 @@
 set -euo pipefail
 
 DIR=~jobrunner/release-hatch
-cp -a ./release-hatch "$DIR"
+SSL_CERT=$DIR/certs/release-hatch.crt
+SSL_KEY=$DIR/certs/release-hatch.key
+SYSTEM_CERTS=/usr/local/share/ca-certificates/release-hatch
+
+mkdir -p $DIR
+cp -a ./release-hatch/* "$DIR"
+
+if ! test -e $SSL_KEY -a -e $SSL_CERT; then
+    # shellcheck disable=SC1090
+    source <(cat /srv/jobrunner/environ/*.env)
+
+    # clean http:// and ports
+    HOSTNAME="$(echo "$RELEASE_HOST" | cut -d'/' -f3 | cut -d':' -f1)"
+
+    mkdir -p "$(dirname $SSL_CERT)"
+
+    # generate a self signed certificate
+    openssl req -x509 -newkey ed25519 -keyout $SSL_KEY -out $SSL_CERT -sha256 -days 365 -nodes \
+	    -subj "/C=GB/L=Lehi/O=OpenSAFELY/CN=$HOSTNAME/emailAddress=tech@opensafely.org" \
+	    -addext "subjectAltName = DNS:$HOSTNAME"
+
+    # ensure self signed is trusted by this machine
+    mkdir -p $SYSTEM_CERTS
+    ln -sf $SSL_CERT $SYSTEM_CERTS/
+    update-ca-certificates
+fi
+
 chown -R jobrunner:jobrunner "$DIR"
 chmod -R go-rwx "$DIR"
 

--- a/run-in-lxd.sh
+++ b/run-in-lxd.sh
@@ -33,6 +33,7 @@ cleanup() {
 trap cleanup EXIT INT
 
 lxc launch "$TEST_IMAGE" "$CONTAINER" --quiet --ephemeral -c security.nesting=True
+lxc exec "$CONTAINER" -- cloud-init status --wait
 
 if test -z "${DEBUG:-}"; then
     # if we're not in debug mode, just copy files. This does not require shiftfs,
@@ -44,6 +45,8 @@ else
     lxc config device add "$CONTAINER" backend-server disk source="$PWD" path=/tests shift=true
 fi
 
+
+lxc exec "$CONTAINER" -- cloud-init status --wait
 # run test script
 set +e # we handle the error manually
 echo -n "Running $SCRIPT in $CONTAINER LXD container..."

--- a/tests/check-release-hatch
+++ b/tests/check-release-hatch
@@ -1,10 +1,9 @@
 #!/bin/bash
 # run release-hatch tests
-docker-compose -f ~jobrunner/release-hatch/docker-compose.yaml exec -T release-hatch python hatch/client.py test
-
+docker-compose -f ~jobrunner/release-hatch/docker-compose.yaml run --rm release-hatch-test
 
 # check CORS preflight
-curl -s --fail localhost:8001 -X OPTIONS \
+curl -s --fail https://localhost -X OPTIONS \
   -H 'Access-Control-Request-Method: GET' \
   -H 'Access-Control-Request-Headers: authorization' \
   -H 'Origin: https://jobs.opensafely.org' \

--- a/tests/check-release-hatch
+++ b/tests/check-release-hatch
@@ -1,12 +1,25 @@
 #!/bin/bash
+
+
+# set DNS for RELEASE_HOST to 127.0.0.1
+source <(cat /srv/jobrunner/environ/*.env)
+HOSTNAME="$(echo "$RELEASE_HOST" | cut -d'/' -f3 | cut -d':' -f1)"
+grep -q "$HOSTNAME" /etc/hosts || echo "127.0.0.1 $HOSTNAME" >> /etc/hosts
+
 # run release-hatch tests
 docker-compose -f ~jobrunner/release-hatch/docker-compose.yaml run --rm release-hatch-test
 
 # check CORS preflight
-curl -s --fail https://localhost -X OPTIONS \
+cors_check=0
+curl -s --fail $RELEASE_HOST -X OPTIONS \
   -H 'Access-Control-Request-Method: GET' \
   -H 'Access-Control-Request-Headers: authorization' \
   -H 'Origin: https://jobs.opensafely.org' \
   -H 'Sec-Fetch-Mode: cors' \
   -H 'Sec-Fetch-Site: same-site' \
-  -H 'Sec-Fetch-Dest: empty'
+  -H 'Sec-Fetch-Dest: empty' || cors_check=$?
+
+if test $cors_check != 0; then
+   echo "CORS preflight check failed with exit code $cors_check"
+   exit $cors_check
+fi

--- a/tpp-backend/README.md
+++ b/tpp-backend/README.md
@@ -9,11 +9,11 @@ access](#setting-up-ssh-access) below before you can log in via ssh.
 
 Once logged into the TPP Level 3 server via RDP, open git-bash and run:
 
-TODO: update the hostname/IP once we have it.
 
 ```bash
-ssh <github username>@opensafely-ttp
+ssh <github username>@opensafely-outputs.tpp
 ```
+
 
 
 ## Setting up ssh access
@@ -25,7 +25,7 @@ Second, you will need to generate a local ssh key on that server.
 
  - *IMPORTANT*: this ssh key **MUST** have a good passphrase.
  - *IMPORTANT*: this ssh key **SHOULD NOT** be registered with your Github
-   account
+   account, we cannot push to git from TPP level 3 anyway.
 
 To generate a new key, open a git-bash terminal
 
@@ -49,26 +49,29 @@ repository. Once this is merged, you should be able to log in to the backend VM.
  - The backend runs in a Hyper-V VM on the host.
  - login to host is via authenticated firewall and RDP, accounts managed by
    TPP.
- - outgoing internet is restricted to https to our our cloudflare IPs,
-   and https and ssh to github.com
+ - Outgoing internet is restricted to https to our our cloudflare IPs
  - TPP maintain a one-way push of medium privacy output files to the
    Level 4 server.
- - as TPP was early adopter, many users have RDP access to this machine.
- - goal is to reduce that to just the OpenSAFELY platform team.
+ - As TPP was early adopter, many users have RDP access to this machine.
+ - Goal is to reduce that to just the OpenSAFELY platform team. As such, we are
+   only granting core OpenSAFELY team access to the VM.
+
 
 ### Level 4 Server
 
- - TPP provide a windows VM.
+ - TPP provide a windows VM on the same host.
  - Login is via same firewall, but separate RDP account.
  - Redaction and publishing happens here.
  - Files pushed here from level 3.
 
 ### Implications
 
- - developers need a local SSH key on the Level 2/3 server to log in to
+ - Developers need a local SSH key on the Level 2/3 server to log in to
    the backend ubuntu server (RDP doesn't do agent forwarding!)
- - backend needs to write files to host filesystem for sync to level 4
-   server, which requires an SMB mount in the backend.
+ - The VM publishes an SMB share with level 4 outputs in, which initially will
+   be synced to the level 4 VM. At somepoint, releases will got via the UI and
+   release-hatch, and this will not be necessary.
+
 
 ### Hyper-V Image
 
@@ -81,4 +84,5 @@ in git-bash on Windows.
 
 Once the VM is deployed, we will maintain it directly, and do not
 anticipate generating VM images regularly.
+
 

--- a/tpp-backend/README.md
+++ b/tpp-backend/README.md
@@ -25,7 +25,7 @@ Second, you will need to generate a local ssh key on that server.
 
  - *IMPORTANT*: this ssh key **MUST** have a good passphrase.
  - *IMPORTANT*: this ssh key **SHOULD NOT** be registered with your Github
-   account, we cannot push to git from TPP level 3 anyway.
+   account, we cannot push to Github from TPP level 3 anyway.
 
 To generate a new key, open a git-bash terminal
 
@@ -49,7 +49,7 @@ repository. Once this is merged, you should be able to log in to the backend VM.
  - The backend runs in a Hyper-V VM on the host.
  - login to host is via authenticated firewall and RDP, accounts managed by
    TPP.
- - Outgoing internet is restricted to https to our our cloudflare IPs
+ - Outgoing internet is restricted to https to our cloudflare IPs
  - TPP maintain a one-way push of medium privacy output files to the
    Level 4 server.
  - As TPP was early adopter, many users have RDP access to this machine.

--- a/tpp-backend/backend.env
+++ b/tpp-backend/backend.env
@@ -5,4 +5,7 @@ BACKEND=tpp
 TEMP_DATABASE_NAME=OPENCoronaTempTables
 
 # Default if unset is cpus-1
-MAX_WORKERS=
+MAX_WORKERS=16
+
+
+RELEASE_HOST=https://opensafely-outputs.tpp


### PR DESCRIPTION
The release-hatch API is used over CORS from a browser in a HTTPS
context, and as such, we need it to have TLS enabled or we get all kinds
of issues.

This PR changes the set up for release-hatch to always run over TLS with
a self-signed cert by default.

We anticipate this cert being replaced with a real one of some kind or
other in situ, but having self signed by default allows us to test our
TLS config locally.
