### PR TITLE
Add note to files which can be hand edited

### DIFF
--- a/jobrunner/secrets-template.env
+++ b/jobrunner/secrets-template.env
@@ -1,6 +1,8 @@
 ### WARNING -  these are secrets that should be kept private 
 #
 # Think before you copy!
+#
+# This file is safe to edit by hand: it will not be overwritten by config management
 
 # Credentials for logging into the job server for this backend
 JOB_SERVER_TOKEN=

--- a/scripts/jobrunner.sh
+++ b/scripts/jobrunner.sh
@@ -62,7 +62,7 @@ test -f $secrets_env || cp jobrunner/secrets-template.env $secrets_env
 
 
 # just make sure local env exists
-test -f "$local_env" || echo "# add local overrides here" > "$local_env"
+test -f "$local_env" || echo "# add local overrides here (this file is safe to edit by hand)" > "$local_env"
 
 # utility for injecting test config
 if test -f "${TEST_CONFIG:-}"; then


### PR DESCRIPTION
We already warn about files which should _not_ be edited (because
changes will be overwritten by config management) but it's helpul to
explitly flag those which _can_ be edited for the avoidance of doubt.