### PR TITLE
Replace systemd slice mechanism with iptables

### DIFF
--- a/jobrunner/jobrunner.service
+++ b/jobrunner/jobrunner.service
@@ -10,24 +10,20 @@ EnvironmentFile=/srv/jobrunner/environ/03_backend.env
 EnvironmentFile=/srv/jobrunner/environ/04_local.env
 WorkingDirectory=/srv/jobrunner/code
 
-# Creates and configures a slice which allows network access to only the IPs
-# listed in DATABASE_IP_LIST. Any Docker container run with:
+# Creates and configures a Docker network which allows network access to only
+# the IPs listed in DATABASE_IP_LIST. Any Docker container run with:
 #
-#     --cgroup-parent=$DATABASE_ACCESS_SLICE
+#     --network=$DATABASE_ACCESS_NETWORK
 #
 # will be subject to this restriction.
 #
 # Set a default empty list so we fail closed. This will be overridden by any
 # value set in the EnvironmentFiles listed above:
 Environment="DATABASE_IP_LIST="
-Environment="DATABASE_ACCESS_SLICE=jobrunner_database_access.slice"
-# Use the `+` prefix to run command as root. The `--runtime` flag prevents this
-# slice config being needlessly persisted to disk
-ExecStartPre=+/usr/bin/systemctl \
-  set-property --runtime \
-  ${DATABASE_ACCESS_SLICE} \
-  IPAddressDeny=any \
-  IPAddressAllow='${DATABASE_IP_LIST}'
+Environment="DATABASE_ACCESS_NETWORK=jobrunner-db"
+# Use the `+` prefix to run command as root
+ExecStartPre=+/usr/local/sbin/jobrunner-network-config.sh \
+  ${DATABASE_ACCESS_NETWORK} ${DATABASE_IP_LIST}
 
 ExecStart=/usr/bin/python3 -m jobrunner.service
 ExecStop=/bin/kill -INT ${MAINPID}

--- a/jobrunner/sbin/jobrunner-network-config.sh
+++ b/jobrunner/sbin/jobrunner-network-config.sh
@@ -1,0 +1,53 @@
+#!/bin/bash
+
+# Creates a Docker network and configures it to have access to only the
+# specified list of IPs. Example usage:
+#
+#   jobrunner-network-config.sh my-network-name 8.8.8.8 170.30.0.0/16
+#
+# Requires root in order to call `iptables`.
+
+set -euo pipefail
+
+network_name="$1"
+shift 1
+
+insert_iptables_rule() {
+  # iptables rule insertion is not idempotent, so we need to check if the rule
+  # already exits or we'll end up with duplicates
+  if ! iptables --check "$@" &>/dev/null; then
+    iptables -I "$@"
+  fi
+}
+
+# Add a default REJECT rule for requests from this interface
+insert_iptables_rule DOCKER-USER -i "$network_name" -j REJECT
+
+# Add ACCEPT rules for each of the supplied arguments
+while [[ "$#" != "0" ]]; do
+  ip_addr_spec="$1"
+  shift 1
+  # If no IPs are supplied we can end up with empty arguments which we need to skip
+  if [[ -z "$ip_addr_spec" ]]; then continue; fi
+  insert_iptables_rule DOCKER-USER -i "$network_name" -d "$ip_addr_spec" -j ACCEPT
+done
+
+# Check if the Docker network already exists and has the expected interface name
+existing_network=$(
+  docker network inspect $network_name \
+  --format '{{ index .Options "com.docker.network.bridge.name" }}' \
+    2>/dev/null \
+  || true
+)
+
+# Create the network if it doesn't exist
+if [[ "$existing_network" != "$network_name" ]]; then
+  # Note that if the network does exist but for some reason does not use the
+  # expected interface name then the below command will blow up, which is
+  # better than adding iptables rules which silently have no effect.
+  docker network create \
+    --driver bridge \
+    -o com.docker.network.bridge.name="$network_name" \
+    "$network_name" \
+      >/dev/null
+fi

--- a/jobrunner/secrets-template.env
+++ b/jobrunner/secrets-template.env
@@ -19,8 +19,10 @@ SLICE_DATABASE_URL=
 FULL_DATABASE_URL=
 
 # Space separated list of IP addresses to which database jobs need access.
-# Full format specification can be found at:
-# https://www.freedesktop.org/software/systemd/man/systemd.resource-control.html#IPAddressAllow=ADDRESS%5B/PREFIXLENGTH%5D%E2%80%A6
+# Note, this will be used as a `--destination` argument in an iptables rule and
+# so various masking options are possible. Full format specification can be
+# found at:
+# https://manpages.debian.org/unstable/iptables/iptables.8.en.html#PARAMETERS
 DATABASE_IP_LIST=
 
 # For EMIS backends

--- a/scripts/jobrunner.sh
+++ b/scripts/jobrunner.sh
@@ -53,6 +53,7 @@ EOF
 }
 
 cp jobrunner/bin/* /srv/jobrunner/bin/
+cp jobrunner/sbin/* /usr/local/sbin
 
 copy_with_warning jobrunner/defaults.env "$defaults_env"
 copy_with_warning "$BACKEND_DIR/backend.env" "$backend_env"


### PR DESCRIPTION
The previous approach relied on some combination of kernel/Docker features which were not availabe in all our production systems.

Here we take a more old-school approach, using a custom Docker network and some iptables rules.