### PR TITLE
feat: de-aggregate filesystem usage

### DIFF
--- a/services/collector/collector.yaml
+++ b/services/collector/collector.yaml
@@ -17,7 +17,12 @@ receivers:
       cpu: {}
       load: {}
       disk: {}
-      filesystem: {}
+      filesystem:
+        include_devices:
+          devices:
+            - /dev/sda1
+            - /dev/sdb1
+          match_type: strict
       network: {}
       paging: {}
       processes: {}
@@ -299,33 +304,6 @@ processors:
           direction: write
         action: insert
         new_name: system.disk.merged.write
-        operations:
-          - action: aggregate_labels
-            aggregation_type: sum
-            label_set: []
-      - include: system.filesystem.usage
-        experimental_match_labels:
-          state: free
-        action: insert
-        new_name: system.filesystem.usage.free
-        operations:
-          - action: aggregate_labels
-            aggregation_type: sum
-            label_set: []
-      - include: system.filesystem.usage
-        experimental_match_labels:
-          state: reserved
-        action: insert
-        new_name: system.filesystem.usage.reserved
-        operations:
-          - action: aggregate_labels
-            aggregation_type: sum
-            label_set: []
-      - include: system.filesystem.usage
-        experimental_match_labels:
-          state: used
-        action: insert
-        new_name: system.filesystem.usage.used
         operations:
           - action: aggregate_labels
             aggregation_type: sum
@@ -679,7 +657,6 @@ processors:
           - system.disk.operation_time
           - system.disk.operations
           - system.filesystem.inodes.usage
-          - system.filesystem.usage
           - system.memory.usage
           - system.network.connections
           - system.network.connections.tcp


### PR DESCRIPTION
* our previous configuration was summing the free space across all disks, but we now want to monitor the space on particular disks individually, so remove the sum config
* I don't know why the monitoring was summed, but with our current Honeycomb package we have huge headroom in terms of event counts, which might not have been the case when this was set up
* explicitly whitelist the two disks that we're interested in, to reduce noise
* honeycomb triggers/graphs will need amending as the data will now be in a slightly different format - instead of one event with (e.g.) system.filesystem.usage.free & system.filesystem.usage.used etc, there will now be multiple events one with `state` like "used" & "free" and the actual value in system.filesystem.usage
* collector config manually tested & working on TPP VM