### PR TITLE
chore: ignore shellcheck failure

### DIFF
--- a/tests/install.sh
+++ b/tests/install.sh
@@ -40,6 +40,7 @@ useradd testpwuser --create-home --shell /bin/bash
 
 # helper function because chpasswd does not error correctly
 test-password() {
+    # shellcheck disable=SC2317
     ! echo "testpwuser:$1" | chpasswd 2>&1 | grep -q "BAD PASSWORD" 
 }
 


### PR DESCRIPTION
* this line appears to be correct but fails on my local shellcheck 0.9.0 (although it currently passes on the CI test's shellcheck 0.7.0, this is an annoyance for me locally)

```
In tests/install.sh line 43:
    ! echo "testpwuser:$1" | chpasswd 2>&1 | grep -q "BAD PASSWORD"
      ^-- SC2317 (info): Command appears to be unreachable. Check usage (or ignore if invoked indirectly).

```
