### PR TITLE
chore: refactor justfile/tests into tests/justfile/tests

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -16,7 +16,7 @@ jobs:
     - name: Checkout
       uses: actions/checkout@v2
     - name: Run lint
-      run: just lint
+      run: just tests/lint
   tests:
     strategy:
       fail-fast: false
@@ -35,6 +35,6 @@ jobs:
     - name: Checkout
       uses: actions/checkout@v2
     - name: Prepare test image & testuser key
-      run: just build
+      run: just tests/build
     - name: Run tests
-      run: just run_test tests/backends/${{ matrix.backend_name }}.sh
+      run: just tests/run_test tests/backends/${{ matrix.backend_name }}.sh

--- a/DEVELOPERS.md
+++ b/DEVELOPERS.md
@@ -56,9 +56,9 @@ To run tests:
 
 To run specific tests (tab completes)
 
-    just run_test tests/$TEST
+    just tests/run_test tests/$TEST
 
 If you specify DEBUG=1, then you will be dropped into a shell inside the docker
 container after the tests has run, e.g. 
 
-    DEBUG=1 just run_test tests/$TEST 
+    DEBUG=1 just tests/run_test tests/$TEST 

--- a/tests/justfile
+++ b/tests/justfile
@@ -1,0 +1,57 @@
+export TESTS := `ls install.sh backends/*.sh`
+export TEST := "true"
+github_actions := env_var_or_default('GITHUB_ACTIONS', "false")
+# run-in-lxd.sh uses this env_var
+export DEBUG := env_var_or_default('DEBUG', "")
+
+
+default:
+  @just --list
+
+# lint some shellscripts
+lint:
+  # run this from the parent directory so that shellcheck can locate the other files referred
+  # to in these scripts
+  cd .. && shellcheck -x */*.sh services/*/*.sh services/jobrunner/bashrc bin/lsjobs run-in-lxd.sh build-lxd-image.sh
+
+# build resources required to run tests
+build: testuser-key build-test-image
+
+# build lxd image for tests
+build-test-image:
+  #!/usr/bin/env bash
+  set -euo pipefail
+
+  test packages.txt -nt .test-image -o ../core-packages.txt -nt .test-image -o ../purge-packages.txt -nt .test-image -o ../build-lxd-image.sh -nt .test-image || exit 0
+  (cd .. && time {{ if github_actions == "true" { "sudo" } else { "" } }} ./build-lxd-image.sh)
+  touch .test-image
+
+# create ssh key for tests
+testuser-key:
+  #!/usr/bin/env bash
+  set -euo pipefail
+
+  test -e keys/testuser && exit 0
+  ssh-keygen -t ed25519 -N "" -C testuser -f keys/testuser.key
+  mv keys/testuser.key.pub keys/testuser
+
+# run all tests
+test: build
+  #!/usr/bin/env bash
+  set -euo pipefail
+
+  for i in $TESTS;
+  do
+    # group output by target when displaying in Github Actions
+    {{ if github_actions == "true" { "echo \"::group::\"$i"  } else { "" } }}
+    {{ just_executable() }} run_test "$i"
+    {{ if github_actions == "true" { "echo \"::endgroup::\"" } else { "" } }}
+  done
+
+# run a specific test
+run_test target: build
+  (cd .. && {{ if github_actions == "true" { "sudo -E" } else { "" } }} ./run-in-lxd.sh {{target}})
+
+# remove temporary files relating to tests
+clean:
+    rm -rf keys/testuser keys/testuser.key .test-image


### PR DESCRIPTION
* `just --list` is getting cluttered - move tests to a separate justfile in `tests/`
* add a reminder in `just test`
* follow-up issue https://github.com/opensafely-core/backend-server/issues/131 