### PR TITLE
feat: create base justfile for the jobrunner user

### DIFF
--- a/justfile-user
+++ b/justfile-user
@@ -1,0 +1,3 @@
+
+default:
+  just -f jobrunner/justfile -l --list-prefix jobrunner/

--- a/scripts/install_jobrunner_user.sh
+++ b/scripts/install_jobrunner_user.sh
@@ -69,3 +69,8 @@ rm -f $HOME_DIR/playbook.md
 cp playbook.md $HOME_DIR/playbook.md
 # clean up old playbook if present
 rm -f /srv/playbook.md
+
+# update user-wide justfiles for management tasks
+cp justfile-user $HOME_DIR/justfile
+mkdir -p $HOME_DIR/jobrunner
+cp services/jobrunner/justfile $HOME_DIR/jobrunner/justfile

--- a/services/jobrunner/justfile
+++ b/services/jobrunner/justfile
@@ -3,6 +3,11 @@
 default:
   @just --list
 
+# show the status of the jobrunner service
+status:
+    sudo systemctl status -n0 jobrunner
+    python3 -m jobrunner.cli.flags get paused
+
 # start the jobrunner service
 start:
     sudo systemctl start jobrunner

--- a/services/jobrunner/justfile
+++ b/services/jobrunner/justfile
@@ -1,0 +1,49 @@
+
+[private]
+default:
+  @just --list
+
+# start the jobrunner service
+start:
+    sudo systemctl start jobrunner
+
+# stop the jobrunner service
+stop:
+    sudo systemctl stop jobrunner
+
+# restart the jobrunner service
+restart:
+    sudo systemctl restart jobrunner
+
+# destroy containers & volumes for all running jobs
+prepare-for-reboot: stop
+    python3 -m jobrunner.cli.prepare_for_reboot
+
+# stop accepting new jobs
+pause:
+    python3 -m jobrunner.cli.flags set paused=true
+
+# start accepting new jobs
+unpause:
+    python3 -m jobrunner.cli.flags set paused=
+
+# show jobrunner logs (limited to 1000 lines) 
+logs lines="1000":
+    journalctl -xe -u jobrunner -n{{ lines }}
+
+# show jobrunner logs for a specific job_id
+logs-id job_id:
+    journalctl -u jobrunner | grep {{ job_id }}
+
+# list all currently running jobs
+jobs-ls:
+    lsjobs
+
+# show docker stats for all currently running jobs
+jobs-stats:
+    docker stats --no-stream
+
+# retry a specific job
+job-retry job_id:
+    python3 -m jobrunner.cli.retry_job {{ job_id }}
+


### PR DESCRIPTION
```
Available recipes:
jobrunner/job-retry job_id   # retry a specific job
jobrunner/jobs-ls            # list all currently running jobs
jobrunner/jobs-stats         # show docker stats for all currently running jobs
jobrunner/logs lines="1000"  # show jobrunner logs (limited to 1000 lines)
jobrunner/logs-id job_id     # show jobrunner logs for a specific job_id
jobrunner/pause              # stop accepting new jobs
jobrunner/prepare-for-reboot # destroy containers & volumes for all running jobs
jobrunner/restart            # restart the jobrunner service
jobrunner/start              # start the jobrunner service
jobrunner/stop               # stop the jobrunner service
jobrunner/unpause            # start accepting new jobs
```
