### PR TITLE
fix: change old environ directory in user.bashrc

### DIFF
--- a/scripts/user.bashrc
+++ b/scripts/user.bashrc
@@ -2,7 +2,7 @@
 # load config into this shell so we can just run stuff
 set -a
 # shellcheck disable=SC1090
-for f in /srv/jobrunner/environ/*.env; do
+for f in /home/jobrunner/config/*.env; do
     . "$f"
 done
 set +a


### PR DESCRIPTION
* introduced in https://github.com/opensafely-core/backend-server/pull/151 
* maybe ./services/jobrunner/bashrc should have been removed in #151 ?