### PR TITLE
chore: quieten a grep on first bootstrap

### DIFF
--- a/scripts/bootstrap.sh
+++ b/scripts/bootstrap.sh
@@ -33,7 +33,7 @@ echo "BACKEND=$BACKEND" > .env
 # also put it in the default profile so everything else has access to it
 mkdir -p /etc/opensafely/profile.d
 BACKEND_PROFILE=/etc/opensafely/profile.d/backend.sh
-grep -q "$BACKEND" $BACKEND_PROFILE || printf "readonly BACKEND=%s\nexport BACKEND" "$BACKEND" >> $BACKEND_PROFILE
+grep -q "$BACKEND" $BACKEND_PROFILE 2>/dev/null || printf "readonly BACKEND=%s\nexport BACKEND" "$BACKEND" >> $BACKEND_PROFILE
 ln -s $BACKEND_PROFILE /etc/profile.d/backend.sh
 
 if [[ "$OSTYPE" == "linux-gnu"* ]]


### PR DESCRIPTION
* grep -q still prints a message if the file doesn't exist, which it won't when bootstrapping a new machine. We can just write this to /dev/null.