### PR TITLE
Move to ehrql:v1

### DIFF
--- a/tests/backends/test.sh
+++ b/tests/backends/test.sh
@@ -30,7 +30,7 @@ test "$(id -g opensafely)" == "10000"
 tout 5s systemctl status jobrunner
 
 # hack to pull in ehrql for this job
-/home/opensafely/jobrunner/code/scripts/update-docker-image.sh ehrql:v0
+/home/opensafely/jobrunner/code/scripts/update-docker-image.sh ehrql:v1
 
 # run a job
 cat << EOF | su - opensafely -c bash

--- a/tests/build-lxd-image.sh
+++ b/tests/build-lxd-image.sh
@@ -17,6 +17,9 @@ lxc exec "$name" -- apt-get upgrade --yes
 sed 's/^#.*//' "$BACKEND_SERVER_PATH"/core-packages.txt | lxc exec "$name" -- xargs apt-get install -y
 sed 's/^#.*//' "$BACKEND_SERVER_PATH"/packages.txt | lxc exec "$name" -- xargs apt-get install -y
 
+# preload ehrql:v1
+lxc exec "$name" -- docker pull ghcr.io/opensafely-core/ehrql:v1
+
 lxc stop "$name"
 time lxc publish --quiet "$name" --alias "$name"
 # GHA version of lxd doesn't have this, so don't error


### PR DESCRIPTION
ghcr.io was being super slow, realised I could cache the docker image in
the lxd image for faster local tests.
