### PR TITLE
Refactor release-hatch tooling

### DIFF
--- a/justfile-user
+++ b/justfile-user
@@ -1,3 +1,5 @@
 
 default:
   @test jobrunner/justfile && just -f jobrunner/justfile -l --list-prefix jobrunner/
+  @echo
+  @test release-hatch/justfile && just -f release-hatch/justfile -l --list-prefix release-hatch/

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -33,6 +33,9 @@ ln -sf /etc/opensafely/profile /etc/profile.d/opensafely.sh
 ln -sf /etc/opensafely/sudoers /etc/sudoers.d/opensafely
 ln -sf /etc/opensafely/ssh.conf /etc/ssh/sshd_config.d/99-opensafely.conf
 
+# create directory for selfsigned test certifcates
+mkdir -p /usr/local/share/ca-certificates/opensafely
+
 # clean up old files
 rm -f /etc/opensafely/ssh-banner
 

--- a/services/release-hatch/deploy.sh
+++ b/services/release-hatch/deploy.sh
@@ -1,8 +1,0 @@
-#!/bin/bash
-set -euo pipefail
-
-# start the docker container
-DIR=~opensafely/release-hatch
-echo "Pulling image"
-docker-compose --no-ansi -f $DIR/docker-compose.yaml pull --quiet release-hatch
-docker-compose --no-ansi -f $DIR/docker-compose.yaml up --detach release-hatch

--- a/services/release-hatch/install.sh
+++ b/services/release-hatch/install.sh
@@ -5,12 +5,13 @@ DIR=~opensafely/release-hatch
 
 mkdir -p $DIR
 cp -a ./services/release-hatch/* "$DIR"
-chown -R opensafely:opensafely "$DIR"
-chmod -R go-rwx "$DIR"
 
-if test "$TEST" = "true"; then
+if test "${TEST:-}" = "true"; then
     just -f $DIR/justfile create-test-certificates
 fi
+
+chown -R opensafely:opensafely "$DIR"
+chmod -R go-rwx "$DIR"
 
 systemctl enable "$DIR/release-hatch.service"
 systemctl enable "$DIR/release-hatch.timer"

--- a/services/release-hatch/install.sh
+++ b/services/release-hatch/install.sh
@@ -2,35 +2,15 @@
 set -euo pipefail
 
 DIR=~opensafely/release-hatch
-SSL_CERT=$DIR/certs/release-hatch.crt
-SSL_KEY=$DIR/certs/release-hatch.key
-SYSTEM_CERTS=/usr/local/share/ca-certificates/release-hatch
 
 mkdir -p $DIR
 cp -a ./services/release-hatch/* "$DIR"
-
-if ! test -e $SSL_KEY -a -e $SSL_CERT; then
-    # shellcheck disable=SC1091
-    . ~opensafely/config/load-env
-
-    # clean http:// and ports
-    HOSTNAME="$(echo "$RELEASE_HOST" | cut -d'/' -f3 | cut -d':' -f1)"
-
-    mkdir -p "$(dirname $SSL_CERT)"
-
-    # generate a self signed certificate
-    openssl req -x509 -newkey ed25519 -keyout $SSL_KEY -out $SSL_CERT -sha256 -days 365 -nodes \
-	    -subj "/C=GB/O=OpenSAFELY/CN=$HOSTNAME/emailAddress=tech@opensafely.org" \
-	    -addext "subjectAltName = DNS:$HOSTNAME"
-
-    # ensure self signed is trusted by this machine
-    mkdir -p $SYSTEM_CERTS
-    ln -sf $SSL_CERT $SYSTEM_CERTS/
-    update-ca-certificates
-fi
-
 chown -R opensafely:opensafely "$DIR"
 chmod -R go-rwx "$DIR"
+
+if test "$TEST" = "true"; then
+    just -f $DIR/justfile create-test-certificates
+fi
 
 systemctl enable "$DIR/release-hatch.service"
 systemctl enable "$DIR/release-hatch.timer"

--- a/services/release-hatch/justfile
+++ b/services/release-hatch/justfile
@@ -13,6 +13,7 @@ deploy: && restart
     echo "Pulling image"
     docker-compose --no-ansi pull --quiet release-hatch
 
+
 # restart release-hatch
 restart *args:
     docker-compose --no-ansi up --no-build {{ args }} --detach release-hatch
@@ -21,25 +22,38 @@ restart *args:
 update-certs:
     #!/bin/bash
     set -euo pipefail
+    # ensure env is loaded 
+    . ~opensafely/config/load-env
 
     echo "Checking for certificate updates"
     openssl s_client -showcerts -connect backends.opensafely.org:443 </dev/null 2>/dev/null| sed -n '/^-----BEGIN CERT/,/^-----END CERT/p' > certs/fullchain.latest.pem
     update=false
-    #
+
+    # if we have no fullchain cert yet
     if ! test -f certs/fullchain.pem; then
+        echo "No fullchain.pem, updating"
         update=true
     # if cert has changed
     elif ! diff -q certs/fullchain.pem certs/fullchain.latest.pem; then
+        echo "fullchain.pem is out of date, updating"
         update=true
     fi
 
     if test "$update" = "true"; then
-        echo "New certificates found, updating and restarting"
         cp certs/fullchain.latest.pem certs/fullchain.pem
-        ln -sf fullchain.pem $SSL_CERT
-        {{ just_executable() }} restart --force-recreate
+
+        # only actually update the certs if we're not inside tests
+        if test "${TEST:-}" = "true"; then
+            echo "Skipping cert update as in TEST env"
+        else
+            ln -sf fullchain.pem $SSL_CERT
+            {{ just_executable() }} restart --force-recreate
+        fi
     fi
     
+# autodeployment target. Update certs and image
+autodeploy: update-certs deploy
+
 
 [private]
 create-test-certificates:

--- a/services/release-hatch/justfile
+++ b/services/release-hatch/justfile
@@ -1,0 +1,74 @@
+export SSL_CERT := "certs/release-hatch.crt"
+export SSL_KEY := "certs/release-hatch.key"
+export SELFSIGNED_CERT := "certs/testing.crt"
+export SELFSIGNED_KEY := "certs/testing.key"
+export SYSTEM_CERTS := "/usr/local/share/ca-certificates/release-hatch"
+
+[private]
+default:
+  @just --list
+
+# pull latest version and deploy
+deploy: && restart
+    echo "Pulling image"
+    docker-compose --no-ansi pull --quiet release-hatch
+
+# restart release-hatch
+restart *args:
+    docker-compose --no-ansi up --no-build {{ args }} --detach release-hatch
+
+# update to the certificate for release-hatch from backends.opensafely.org
+update-certs:
+    #!/bin/bash
+    set -euo pipefail
+
+    echo "Checking for certificate updates"
+    openssl s_client -showcerts -connect backends.opensafely.org:443 </dev/null 2>/dev/null| sed -n '/^-----BEGIN CERT/,/^-----END CERT/p' > certs/fullchain.latest.pem
+    update=false
+    #
+    if ! test -f certs/fullchain.pem; then
+        update=true
+    # if cert has changed
+    elif ! diff -q certs/fullchain.pem certs/fullchain.latest.pem; then
+        update=true
+    fi
+
+    if test "$update" = "true"; then
+        echo "New certificates found, updating and restarting"
+        cp certs/fullchain.latest.pem certs/fullchain.pem
+        ln -sf fullchain.pem $SSL_CERT
+        {{ just_executable() }} restart --force-recreate
+    fi
+    
+
+[private]
+create-test-certificates:
+    #!/bin/bash 
+    set -euo pipefail
+
+    if test -f $SSL_KEY -o -f $SSL_CERT; then
+        echo "$SSL_KEY and/or $SSL_CERT already exist"
+        exit;
+    fi
+
+    . ~opensafely/config/load-env
+
+    HOSTNAME="$(echo "$RELEASE_HOST" | cut -d'/' -f3 | cut -d':' -f1)"
+    mkdir -p "$(dirname $SSL_CERT)"
+
+    # generate a self signed certificate
+    openssl req -x509 -newkey ed25519 -keyout $SELFSIGNED_KEY -out $SELFSIGNED_CERT \
+        -sha256 -days 365 -nodes \
+        -subj "/C=GB/O=OpenSAFELY/CN=$HOSTNAME/emailAddress=test@example.com" \
+        -addext "subjectAltName = DNS:$HOSTNAME"
+
+    # Relative link to the selfsigned cert
+    # Needs to be relative, as the whole certs/ dir is mounted as a volume
+    ln -s $(basename $SELFSIGNED_CERT) $SSL_CERT
+    ln -s $(basename $SELFSIGNED_KEY) $SSL_KEY
+
+    # ensure self signed is trusted by this machine
+    ln -sf $PWD/$SELFSIGNED_CERT /usr/local/share/ca-certificates/opensafely/
+    update-ca-certificates
+
+

--- a/services/release-hatch/release-hatch.service
+++ b/services/release-hatch/release-hatch.service
@@ -4,7 +4,7 @@ Wants=release-hatch.timer
 
 [Service]
 WorkingDirectory=/home/opensafely/release-hatch
-ExecStart=/usr/local/bin/just deploy
+ExecStart=/usr/local/bin/just autodeploy
 User=opensafely
 Type=oneshot
 

--- a/services/release-hatch/release-hatch.service
+++ b/services/release-hatch/release-hatch.service
@@ -3,8 +3,8 @@ Description=Update release-hatch service
 Wants=release-hatch.timer
 
 [Service]
-WorkingDirectory=/home/opensafely
-ExecStart=/home/opensafely/release-hatch/deploy.sh
+WorkingDirectory=/home/opensafely/release-hatch
+ExecStart=/usr/local/bin/just deploy
 User=opensafely
 Type=oneshot
 

--- a/tests/config.env
+++ b/tests/config.env
@@ -1,3 +1,4 @@
 # config for test
 # This will be injected in 04_local.env to provide values for the tests to run
 JOB_SERVER_TOKEN="test-test-test-test-test-test-test-test"
+TEST=true


### PR DESCRIPTION
This moves release-hatch to using a justfile to manage operations, like
we did with job-runner.

It also adds support for automatically pulling the latest LetsEncrypt
certificates as part of the regular deployment, fixing #184.

It formalises the previously adhoc method of cert management, namedly
using relative sym links in the `certs/` subdir.  It also adds some
protection to the test-only selfsigned cert generation code, so it
should never happen in production.
