### PR TITLE
Allow for per-backend docker-compose overrides for release-hatch

### DIFF
--- a/backends/emis/release-hatch.override.yaml
+++ b/backends/emis/release-hatch.override.yaml
@@ -1,0 +1,8 @@
+# docker-compose version on 20.04 (v1.25) does not support the version-less
+# compose specfication, so we explicitly set the highest version
+# it supports.
+version: "3.7"
+services:
+  release-hatch:
+    security_opt:
+      - seccomp:unconfined

--- a/services/release-hatch/install.sh
+++ b/services/release-hatch/install.sh
@@ -2,9 +2,14 @@
 set -euo pipefail
 
 DIR=~opensafely/release-hatch
+OVERRIDE_FILE="backends/$BACKEND/release-hatch.override.yaml"
 
 mkdir -p $DIR
 cp -a ./services/release-hatch/* "$DIR"
+
+if test -f "$OVERRIDE_FILE"; then
+    cp "$OVERRIDE_FILE" "$DIR/docker-compose.override.yaml"
+fi
 
 if test "${TEST:-}" = "true"; then
     just -f $DIR/justfile create-test-certificates


### PR DESCRIPTION
Use it to disable seccomp in emis, due to old docker seccomp profiles
blocking newer glibc syscalls

Fixes #185
