### PR TITLE
fix: do not write junk into ssh authorized_keys

### DIFF
--- a/scripts/update-ssh.sh
+++ b/scripts/update-ssh.sh
@@ -22,7 +22,7 @@ else
     # note: a quirk of the github ssh api here is that a non-existent user
     # returns an empty 200 response. Which is handy here for using with test
     # users
-    curl -s -f "https://github-proxy.opensafely.org/$user.keys" >> "$tmp"
+    curl --silent --fail "https://github-proxy.opensafely.org/$user.keys" >> "$tmp"
 fi
 
 # replace current authorized_keys

--- a/scripts/update-ssh.sh
+++ b/scripts/update-ssh.sh
@@ -22,7 +22,7 @@ else
     # note: a quirk of the github ssh api here is that a non-existent user
     # returns an empty 200 response. Which is handy here for using with test
     # users
-    curl -s "https://github-proxy.opensafely.org/$user.keys" >> "$tmp"
+    curl -s -f "https://github-proxy.opensafely.org/$user.keys" >> "$tmp"
 fi
 
 # replace current authorized_keys


### PR DESCRIPTION
* if the proxy has an issue & returns 502 bad gateway, `-f` will cause curl (& the script) to abort - instead of writing junk to the authorized_keys files & locking everyone out
* fixes https://github.com/opensafely-core/backend-server/issues/200