### PR TITLE
Switch TPP to use airlock

### DIFF
--- a/backends/tpp/backend.env
+++ b/backends/tpp/backend.env
@@ -11,6 +11,7 @@ MAX_WORKERS=10
 HIGH_PRIVACY_ARCHIVE_DIR=/srv/high_privacy/archive/archived_workspaces
 
 RELEASE_HOST=https://tpp.backends.opensafely.org
+DJANGO_ALLOWED_HOSTS=tpp.backends.opensafely.org
 
 # TPP backend default limits
 DEFAULT_JOB_CPU_COUNT=4

--- a/justfile
+++ b/justfile
@@ -103,7 +103,7 @@ manage-emis: install update-users install-jobrunner install-release-hatch
 manage-test: install-packages install update-users install-jobrunner install-airlock install-osrelease install-collector
 
 [private]
-manage-tpp: install-packages install update-users install-jobrunner install-release-hatch install-collector install-timers
+manage-tpp: install-packages install update-users install-jobrunner install-airlock install-collector install-timers
 
 test:
   echo "Please see `just tests/`"

--- a/tests/backends/tpp.sh
+++ b/tests/backends/tpp.sh
@@ -20,8 +20,8 @@ systemctl status jobrunner || { journalctl -u jobrunner --no-pager; exit 1; }
 # test collector service up
 systemctl status collector || { journalctl -u collector --no-pager; exit 2; }
 
-# run release-hatch tests
-./tests/check-release-hatch.sh
+# run airlock tests
+./tests/check-airlock.sh
 
 msg="Wrong scheme for MS-SQL URL"
 rc=0


### PR DESCRIPTION
* we're going to replace release-hatch with airlock (they share the
  same port)
* [x] requires current (unused) release-hatch manually disabling on TPP before running this
  installer
* [x] requires the following config adding to secrets.env on the TPP server:
  * [x] `DJANGO_SECRET_KEY`
  * [x] `AIRLOCK_API_TOKEN` (this can re-use `JOB_SERVER_TOKEN` as per the template file)
