### PR TITLE
Create failing test for airlock/workdir

### DIFF
--- a/tests/backends/tpp.sh
+++ b/tests/backends/tpp.sh
@@ -7,7 +7,7 @@ set -euo pipefail
 
 just manage
 # run again to check for idempotency
-just manage
+# just manage
 
 # test for ssh keys
 grep -q SimonDavy@OPENCORONA ~bloodearnest/.ssh/authorized_keys


### PR DESCRIPTION
* this was silently passing because we re-run just manage