### PR TITLE
Switch out release-hatch for airlock in the welcome messages

### DIFF
--- a/justfile-user
+++ b/justfile-user
@@ -2,4 +2,4 @@
 default:
   @test jobrunner/justfile && just -f jobrunner/justfile -l --list-prefix jobrunner/
   @echo
-  @test release-hatch/justfile && just -f release-hatch/justfile -l --list-prefix release-hatch/
+  @test airlock/justfile && just -f airlock/justfile -l --list-prefix airlock/

--- a/scripts/user.bashrc
+++ b/scripts/user.bashrc
@@ -14,7 +14,7 @@ Medium privacy files are at \033[1m$MEDIUM_PRIVACY_STORAGE_BASE\033[0m
 High privacy files are at \033[1m$HIGH_PRIVACY_STORAGE_BASE\033[0m
 
 jobrunner: ~/jobrunner
-release-hatch: ~/release-hatch
+airlock: ~/airlock
 collector: ~/collector
 
 Please consult ~/playbook.md for operational documentation, or run: just


### PR DESCRIPTION
* release-hatch is removed from all production systems so no need to maintain multiple versions of this
* fixes #215 
