### PR TITLE
Hardcode all our DNS names in /etc/hosts

### DIFF
--- a/etc/opensafely/hosts
+++ b/etc/opensafely/hosts
@@ -1,0 +1,12 @@
+## start opensafely dns
+
+# Hardcoded values for our core DNS names
+157.245.31.108 jobs.opensafely.org github-proxy.opensafely.org docker-proxy.opensafely.org collector.opensafely.org
+
+# ubuntu archives.
+# /etc/hosts can't do round robin DNS, so we have to pick one IP
+# TODO: add DNS for alternative archives as needed (e.g. aws mirror for EMIS)
+185.125.190.39 archive.ubuntu.com security.ubuntu.com
+#185.125.190.36 archive.ubuntu.com security.ubuntu.com
+
+## end opensafely dns

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -61,8 +61,12 @@ chmod a+rx /usr/local/bin
 
 systemctl reload ssh
 
-# hardcode /etc/hosts entries so we don't need DNS
+# disable cloud-init management of /etc/hosts
+echo -e "manage_etc_hosts: false" > /etc/cloud/cloud.cfg.d/99-opensafely.cfg
+# remove confusing banner in /etc/hosts if present
+sed -i.bak -z "s/# Your system has configured 'manage_etc_hosts'.*cloud-config from user-data\n#\n//" /etc/hosts
 
+# hardcode /etc/hosts entries so we don't need DNS
 if grep -q "## start opensafely dns" /etc/hosts; then
     # -z use NULL for new line, enables multiline matching
     # first -e adds the current file content

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -60,3 +60,15 @@ cp bin/otel-cli /usr/local/bin/
 chmod a+rx /usr/local/bin
 
 systemctl reload ssh
+
+# hardcode /etc/hosts entries so we don't need DNS
+
+if grep -q "## start opensafely dns" /etc/hosts; then
+    # -z use NULL for new line, enables multiline matching
+    # first -e adds the current file content
+    # second -e removes the old file content
+    sed -z -e '/## start opensafely dns.*## end opensafely dns/r etc/opensafely/hosts' -e 's/## start opensafely dns.*## end opensafely dns//' -i.bak /etc/hosts
+else
+    echo "" >> /etc/hosts
+    cat etc/opensafely/hosts >> /etc/hosts
+fi


### PR DESCRIPTION
This should improve reliability, and enable turning off external DNS
too.

Fixes #206
