### PR TITLE
Expose our hardcoded DNS to airloack container

### DIFF
--- a/services/airlock/docker-compose.yaml
+++ b/services/airlock/docker-compose.yaml
@@ -12,6 +12,7 @@ services:
     ports:
       - "443:8000"
     user: 10000:10000
+    dns: 127.0.0.1  # disable dns, as there's no resolver running inside the container
     env_file:
       - /home/opensafely/config/01_defaults.env
       - /home/opensafely/config/02_secrets.env
@@ -28,3 +29,5 @@ services:
       - /srv/medium_privacy/workspaces:/workspaces:ro
       - /srv/medium_privacy/requests:/requests
       - ./certs:/certs
+      # use our hardcoded DNS
+      - /etc/hosts:/etc/hosts


### PR DESCRIPTION
Disable any normal docker dns in airlock container by passing loopback
IP, which doesn't have a resolver running
