### PR TITLE
Add backends.opensafely.org to DNS

### DIFF
--- a/etc/opensafely/hosts
+++ b/etc/opensafely/hosts
@@ -1,2 +1,2 @@
 # Hardcoded values for our core DNS names
-157.245.31.108 jobs.opensafely.org github-proxy.opensafely.org docker-proxy.opensafely.org collector.opensafely.org
+157.245.31.108 jobs.opensafely.org github-proxy.opensafely.org docker-proxy.opensafely.org collector.opensafely.org backends.opensafely.org


### PR DESCRIPTION
This is needed to keep airlocks TLS certs up to date.
