### PR TITLE
Remove hardcoded otel service name

### DIFF
--- a/backends/test/backend.env
+++ b/backends/test/backend.env
@@ -6,6 +6,4 @@ USING_DUMMY_DATA_BACKEND=True
 # Default if unset is cpus-1
 MAX_WORKERS=
 
-OTEL_SERVICE_NAME=test-backend
-
 DJANGO_ALLOWED_HOSTS=localhost

--- a/backends/tpp/backend.env
+++ b/backends/tpp/backend.env
@@ -18,7 +18,3 @@ DEFAULT_JOB_CPU_COUNT=4
 DEFAULT_JOB_MEMORY_LIMIT=128G
 
 ENABLE_MAINTENANCE_MODE_THREAD=true
-
-# TODO: this should probably be tpp-backend or tpp-jobrunner, but requires
-# coordinated renaming the env in HC
-OTEL_SERVICE_NAME=jobrunner


### PR DESCRIPTION
As we are now emitting telemetry from multiple services: jobrunner and
airlock.  These have default service names/datasets
