### PR TITLE
Fix airlock homepage test

### DIFF
--- a/tests/check-airlock.sh
+++ b/tests/check-airlock.sh
@@ -8,8 +8,8 @@ HOSTNAME="$(echo "$RELEASE_HOST" | cut -d'/' -f3 | cut -d':' -f1)"
 grep -q "$HOSTNAME" /etc/hosts || echo "127.0.0.1 $HOSTNAME" >> /etc/hosts
 
 # simple test of the running airlock
-curl -s --fail "$RELEASE_HOST" -o /tmp/airlock-homepage.html
-grep "<title>Airlock</title>" /tmp/airlock-homepage.html
+curl -sL --fail "$RELEASE_HOST" -o /tmp/airlock-homepage.html
+grep "<title>Login | Airlock</title>" /tmp/airlock-homepage.html
 
 # verify that the workspace mount is read-only
 if docker exec airlock touch /workspaces/test; then


### PR DESCRIPTION
* -L because `/` now redirects to `/workspaces` or `/login`
* fix the title element accordingly