### PR TITLE
Fix test config to pass on 22.04

### DIFF
--- a/tests/config.env
+++ b/tests/config.env
@@ -1,4 +1,5 @@
 # config for test
 # This will be injected in 04_local.env to provide values for the tests to run
 JOB_SERVER_TOKEN="test-test-test-test-test-test-test-test"
+AIRLOCK_API_TOKEN="test-test-test-test-test-test-test-test"
 TEST=true


### PR DESCRIPTION
We define `AIRLOCK_API_TOKEN=$JOB_SERVER_TOKEN` in 02_secrets.env, which
works fine when JOB_SERVER_TOKEN is defined *beforehand*. But the
tests/config.env gets added to 04_local.env, which sets JOB_SERVER_TOKEN
to a test value later on.

For some reason, in 20.04, this was no problem, and AIRLOCK_API_TOKEN
was set to the right test value. But in 22.04, docker-compose ends up
not setting AIRLOCK_API_TOKEN from the 04_secret.env values.

I am not sure why, but possibly some difference means that
docker-compose loads envfiles differently, but this is more strict so is
not a bad thing.
