### PR TITLE
Keep actions in workflow up-to-date

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,7 @@
+version: 2
+
+updates:
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "monthly"

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -16,7 +16,9 @@ jobs:
     steps:
     - name: Install lint dependencies
       run: sudo apt-get install -y shellcheck
-    - uses: extractions/setup-just@69d82fb0233557aec017ef13706851d0694e0f1d
+    - uses: "opensafely-core/setup-action@v1"
+      with:
+        install-just: true
     - name: Checkout
       uses: actions/checkout@v4
     - name: Run lint
@@ -35,7 +37,9 @@ jobs:
         sudo snap set lxd shiftfs.enable=true || { sleep 10 && sudo snap set lxd shiftfs.enable=true; }
         sudo lxd init --auto
         sudo lxc info
-    - uses: extractions/setup-just@69d82fb0233557aec017ef13706851d0694e0f1d
+    - uses: "opensafely-core/setup-action@v1"
+      with:
+        install-just: true
     - name: Checkout
       uses: actions/checkout@v4
     - name: Prepare test image & testuser key

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -18,7 +18,7 @@ jobs:
       run: sudo apt-get install -y shellcheck
     - uses: extractions/setup-just@69d82fb0233557aec017ef13706851d0694e0f1d
     - name: Checkout
-      uses: actions/checkout@v2
+      uses: actions/checkout@v4
     - name: Run lint
       run: just tests/lint
   tests:
@@ -37,7 +37,7 @@ jobs:
         sudo lxc info
     - uses: extractions/setup-just@69d82fb0233557aec017ef13706851d0694e0f1d
     - name: Checkout
-      uses: actions/checkout@v2
+      uses: actions/checkout@v4
     - name: Prepare test image & testuser key
       run: just tests/build
     - name: Run tests


### PR DESCRIPTION
This PR updates the existing actions, and enables Dependabot to check for updates in future. It should remove the Actions warnings of `checkout@v2` using an old Node.js version.