### PR TITLE
Fix logging to be persistant

### DIFF
--- a/etc/opensafely/sudoers
+++ b/etc/opensafely/sudoers
@@ -7,4 +7,12 @@ Defaults logfile=/var/log/sudo.log
 # developers group has sudo access
 %developers  ALL=(ALL:ALL) ALL
 
-
+# opensafely user can manage some services
+%opensafely ALL= NOPASSWD: /usr/bin/systemctl restart jobrunner*
+%opensafely ALL= NOPASSWD: /usr/bin/systemctl start jobrunner*
+%opensafely ALL= NOPASSWD: /usr/bin/systemctl stop jobrunner*
+%opensafely ALL= NOPASSWD: /usr/bin/systemctl status jobrunner*
+%opensafely ALL= NOPASSWD: /usr/bin/journalctl -u jobrunner*
+%opensafely ALL= NOPASSWD: /usr/bin/journalctl -t jobrunner*
+%opensafely ALL= NOPASSWD: /usr/bin/journalctl -u airlock*
+%opensafely ALL= NOPASSWD: /usr/bin/journalctl -t airlock*

--- a/scripts/install_opensafely_user.sh
+++ b/scripts/install_opensafely_user.sh
@@ -43,3 +43,5 @@ grep -q ".bashrc-opensafely" $user_bashrc || echo "test -f $opensafely_bashrc &&
 
 # update user-wide justfiles for management tasks
 cp justfile-user $HOME_DIR/justfile
+
+chown -R opensafely:opensafely $HOME_DIR

--- a/services/airlock/docker-compose.yaml
+++ b/services/airlock/docker-compose.yaml
@@ -9,6 +9,10 @@ services:
     init: true
     restart: unless-stopped
     network_mode: bridge
+    logging:
+      driver: journald
+      options:
+        tag: airlock
     ports:
       - "443:8000"
     user: 10000:10000

--- a/services/airlock/justfile
+++ b/services/airlock/justfile
@@ -18,6 +18,10 @@ deploy: && restart
 restart *args:
     docker-compose --ansi never up --no-build {{ args }} --detach airlock
 
+# show airlock logs
+logs *args:
+    sudo journalctl -t airlock {{ args }}
+
 # update to the certificate for airlock from backends.opensafely.org
 update-certs:
     #!/bin/bash

--- a/services/jobrunner/docker-compose.yaml
+++ b/services/jobrunner/docker-compose.yaml
@@ -9,6 +9,10 @@ services:
     init: true
     restart: unless-stopped
     network_mode: bridge
+    logging:
+      driver: journald
+      options:
+        tag: jobrunner
     user: 10000:10000
     # run as the the current user to preserve file permissions
     group_add: ["${DOCKER_HOST_GROUPID}"]

--- a/services/jobrunner/jobrunner.sudo
+++ b/services/jobrunner/jobrunner.sudo
@@ -1,5 +1,0 @@
-%opensafely ALL= NOPASSWD: /usr/bin/systemctl restart jobrunner*
-%opensafely ALL= NOPASSWD: /usr/bin/systemctl start jobrunner*
-%opensafely ALL= NOPASSWD: /usr/bin/systemctl stop jobrunner*
-%opensafely ALL= NOPASSWD: /usr/bin/systemctl status jobrunner*
-%opensafely ALL= NOPASSWD: /usr/bin/journalctl -u jobrunner*

--- a/services/jobrunner/justfile
+++ b/services/jobrunner/justfile
@@ -8,10 +8,6 @@ default:
 status:
     docker compose status jobrunner
 
-# start the jobrunner service
-start:
-    sudo systemctl start jobrunner
-
 # stop the jobrunner service
 stop:
     docker-compose stop
@@ -19,6 +15,8 @@ stop:
 # restart the jobrunner service
 restart *args:
     docker-compose up --no-build {{ args }} --detach jobrunner
+
+alias start:=restart
 
 # Update jobrunner and restart
 deploy: && restart

--- a/services/jobrunner/justfile
+++ b/services/jobrunner/justfile
@@ -41,11 +41,11 @@ unpause:
 
 # show jobrunner logs (using `docker compose logs`)
 logs *args:
-    docker compose logs {{ args }} jobrunner
+    sudo journalctl -t jobrunner {{ args }}
 
 # show jobrunner logs for a specific job_id
 logs-id job_id:
-    docker compose logs |& grep {{ job_id }}
+    sudo journalctl -t jobrunner -g {{ job_id }}
 
 # list all currently running jobs
 jobs-ls:

--- a/services/jobrunner/justfile
+++ b/services/jobrunner/justfile
@@ -22,7 +22,7 @@ alias start:=restart
 deploy: && restart
     echo "Pulling image"
     docker compose pull --quiet jobrunner
-    
+
 # run jobrunner db migrations
 migrate:
     docker compose run jobrunner python3 -m jobrunner.cli.migrate
@@ -79,9 +79,10 @@ update-docker-image image:
     docker pull docker-proxy.opensafely.org/opensafely-core/{{ image }}
     # tag as if we'd pulled direct from ghcr.io 
     docker tag docker-proxy.opensafely.org/opensafely-core/{{ image }} ghcr.io/opensafely-core/{{ image }}
-    docker image prune --force --filter "label=org.opensafely.action={{ image }}"
+    action_name="$(echo {{ image }} | awk -F: '{print $1}')"
+    # delete dangling version of this image 
+    docker image prune --force --filter "label=org.opensafely.action=$action_name"
 
 # add a job run run
 add-job repo action:
     docker compose run jobrunner python3 -m jobrunner.cli.add_job {{ repo }} {{ action }}
-

--- a/tests/backends/test.sh
+++ b/tests/backends/test.sh
@@ -61,7 +61,7 @@ EOF
 
 tout 60s bash "$script" || { docker compose -f opensafely/jobrunner/docker-compose.yaml logs jobrunner; exit 1; }
 
-systemctl status collector || { journalctl -u collector; exit 1; }
+systemctl status --no-pager collector || { journalctl -u collector; exit 1; }
 
 # run airlock tests
 ./tests/check-airlock.sh


### PR DESCRIPTION
Use journald for logging

Includes a few other driveby fixes in the process.

- **driveby: fix just start**
- **Only prune old action images for the image we just updated**
- **Use journald for docker-compose logs**
- **No pager in tests, as it hangs interactive local testing**
