### PR TITLE
Enter db-maintenance immediately on running command

### DIFF
--- a/services/jobrunner/justfile
+++ b/services/jobrunner/justfile
@@ -65,11 +65,11 @@ kill-job *args:
 
 # manually enable database maintenance mode. Kill and re-queue all db jobs.
 db-maintenance-on:
-    docker compose run jobrunner python3 -m jobrunner.cli.flags set manual-db-maintenance=on
+    docker compose run jobrunner python3 -m jobrunner.cli.flags set mode=db-maintenance manual-db-maintenance=on
 
 # manually disable database maintenance mode
 db-maintenance-off:
-    docker compose run jobrunner python3 -m jobrunner.cli.flags set manual-db-maintenance=
+    docker compose run jobrunner python3 -m jobrunner.cli.flags set mode= manual-db-maintenance=
 
 # update docker image
 update-docker-image image:


### PR DESCRIPTION
Previously we would only enter db-maintenance on the next iteration of the maintenance checker thread which can be up to 5 minutes. Additionally, if the thread was disabled for some reason we would never enter maintenance mode.

I think the least surprising behaviour here is that running the command switches database maintenance mode instantly.

Fixes https://github.com/opensafely-core/job-runner/issues/764