### PR TITLE
Temporarily remove `readonly` from BACKEND var

### DIFF
--- a/scripts/bootstrap.sh
+++ b/scripts/bootstrap.sh
@@ -33,7 +33,7 @@ echo "BACKEND=$BACKEND" > .env
 # also put it in the default profile so everything else has access to it
 mkdir -p /etc/opensafely/profile.d
 BACKEND_PROFILE=/etc/opensafely/profile.d/backend.sh
-grep -q "$BACKEND" $BACKEND_PROFILE 2>/dev/null || printf "readonly BACKEND=%s\nexport BACKEND" "$BACKEND" >> $BACKEND_PROFILE
+grep -q "$BACKEND" $BACKEND_PROFILE 2>/dev/null || printf "BACKEND=%s\nexport BACKEND" "$BACKEND" >> $BACKEND_PROFILE
 ln -sf $BACKEND_PROFILE /etc/profile.d/backend.sh
 
 if [[ "$OSTYPE" == "linux-gnu"* ]]


### PR DESCRIPTION
This caused us problems because a later script attempts to set `backend` again (to the same value) causing the whole thing to error out.

The proper solution here is to refactor things so it's clear exactly which parts of the system are responsible for setting which environment variables (see #257). But we did the quick fix directly on the server, and this change makes the bootstrap script reflect the current state of the machine which seems the safest way to park things for now.

Associated Slack threads:
https://bennettoxford.slack.com/archives/C069YDR4NCA/p1733144179614949 https://bennettoxford.slack.com/archives/C02GL3A9THD/p1731000367418999