### PR TITLE
Map uid/username in airlock container

### DIFF
--- a/services/airlock/docker-compose.yaml
+++ b/services/airlock/docker-compose.yaml
@@ -30,4 +30,10 @@ services:
       - /srv/medium_privacy/requests:/requests
       - ./certs:/certs
       # use our hardcoded DNS
-      - /etc/hosts:/etc/hosts
+      - /etc/hosts:/etc/hosts:ro
+      # map opensafely user/group/uid/gid info from host. Supresses confusing
+      # error message.
+      # Note: this is *required* for run-one-constantly to work
+      - /etc/passwd:/etc/passwd:ro
+      - /etc/group:/etc/group:ro
+

--- a/tests/check-airlock.sh
+++ b/tests/check-airlock.sh
@@ -16,3 +16,11 @@ if docker exec airlock touch /workspaces/test; then
   echo "airlock:/workspaces unexpectedly writable"
   exit 1
 fi
+
+# verify the background uploaded process is running
+if ! docker exec airlock pgrep --full run_file_uploader; then
+  echo "Could not detect the background run_file_uploader process"
+  echo "docker exec airlock ps aux"
+  docker exec airlock ps aux
+  exit 1
+fi


### PR DESCRIPTION
Turns out, run-one-constantly needs a valid username for the running uid.  We'd already done this with job-server as a slight UX improvement, this change adds it to airlock config, with a note that is required.

Added test that the background file uploader process is definitely running.