### PR TITLE
Add a generic just jobrunner/cli command

### DIFF
--- a/services/jobrunner/justfile
+++ b/services/jobrunner/justfile
@@ -24,21 +24,25 @@ deploy: && restart
     echo "Pulling image"
     docker compose pull --quiet jobrunner
 
+# Run a jobrunner cli command
+cli command *ARGS:
+    {{ jobrunner_cli }}.{{ command }} {{ ARGS }}
+
 # run jobrunner db migrations
 migrate:
-    {{ jobrunner_cli }}.migrate
+    {{ just_executable() }} cli migrate
 
 # destroy containers & volumes for all running jobs
 prepare-for-reboot: stop
-    {{ jobrunner_cli }}.prepare_for_reboot
+    {{ just_executable() }} cli prepare_for_reboot
 
 # stop accepting new jobs
 pause:
-    {{ jobrunner_cli }}.flags set paused=true
+    {{ just_executable() }} cli flags set paused=true
 
 # start accepting new jobs
 unpause:
-    {{ jobrunner_cli }}.flags set paused=
+    {{ just_executable() }} cli flags set paused=
 
 # show jobrunner logs (using `docker compose logs`)
 logs *args:
@@ -58,19 +62,19 @@ jobs-stats:
 
 # retry a specific job
 job-retry job_id:
-    {{ jobrunner_cli }}.retry_job {{ job_id }}
+    {{ just_executable() }} cli retry_job {{ job_id }}
 
 # kill a job
 kill-job *args:
-    {{ jobrunner_cli }}.kill_job {{ args }}
+    {{ just_executable() }} cli kill_job {{ args }}
 
 # manually enable database maintenance mode. Kill and re-queue all db jobs.
 db-maintenance-on:
-    {{ jobrunner_cli }}.flags set mode=db-maintenance manual-db-maintenance=on
+    {{ just_executable() }} cli flags set mode=db-maintenance manual-db-maintenance=on
 
 # manually disable database maintenance mode
 db-maintenance-off:
-    {{ jobrunner_cli }}.flags set mode= manual-db-maintenance=
+    {{ just_executable() }} cli flags set mode= manual-db-maintenance=
 
 # update docker image
 update-docker-image image:
@@ -86,4 +90,4 @@ update-docker-image image:
 
 # add a job run run
 add-job *args:
-    {{ jobrunner_cli }}.add_job {{ args }}
+    {{ just_executable() }} cli add_job {{ args }}


### PR DESCRIPTION
This makes it easier to run cli commands that we don't necessarily want to add as permanent shortcuts (e.g. the add_backend_to_job and add_backend_to_flags commands to update jobs in the db - we expect these to only run on the dbs while still in the backends, and to be removed in the near future)