### PR TITLE
Fix brace escaping in justfile

### DIFF
--- a/services/jobrunner/justfile
+++ b/services/jobrunner/justfile
@@ -30,7 +30,6 @@ restart-if-running:
 
 # Update jobrunner and restart
 deploy: && restart-if-running
-    echo "Pulling image"
     docker compose pull --quiet jobrunner
 
 # Run a jobrunner cli command

--- a/services/jobrunner/justfile
+++ b/services/jobrunner/justfile
@@ -23,7 +23,9 @@ restart-if-running:
     #!/usr/bin/env bash
     set -euo pipefail
 
-    JOBRUNNER_STATE=`docker compose ps --format "\{\{.State\}\}" jobrunner`
+    # The quadruple opening braces are not a typo: they are how we have to escape the braces
+    # inside a Justfile (the closing braces do not need escaping)
+    JOBRUNNER_STATE=`docker compose ps --format "{{{{.State}}" jobrunner`
     if [ "$JOBRUNNER_STATE" = "running" ]; then
         docker compose up --no-build --detach jobrunner
     fi


### PR DESCRIPTION
The previous version resulted in JOBRUNNER_STATE always taking the literal value `\{\{.State\}\}` and so never considered the container to be running and so never restarted it.