### PR TITLE
Add `just apt-upgrade` command

### DIFF
--- a/justfile
+++ b/justfile
@@ -91,3 +91,7 @@ manage-tpp: install-packages install update-users install-jobrunner install-airl
 
 test:
   echo "Please see `just tests/`"
+
+# upgrade all apt packages
+apt-upgrade:
+  apt-get update && apt-get upgrade -y && apt-get autoremove -y

--- a/justfile
+++ b/justfile
@@ -94,4 +94,30 @@ test:
 
 # upgrade all apt packages
 apt-upgrade:
-  apt-get update && apt-get upgrade -y && apt-get autoremove -y
+  #!/bin/bash
+  set -euo pipefail
+
+  package_to_hold='docker.io'
+
+  apt-get update
+  apt-mark hold "$package_to_hold"
+  apt-get upgrade -y
+  apt-get autoremove -y
+
+  if apt list --upgradable "$package_to_hold" 2>/dev/null | grep -qF "$package_to_hold"; then
+      echo
+      echo "  => WARNING <="
+      echo
+      echo "  The '$package_to_hold' package has an update pending. This usually requires"
+      echo "  a restart of all running Docker containers. To avoid disruption to user"
+      echo "  jobs you should first run a prepare_for_reboot on the controller."
+      echo
+      echo "  Note that jobs will have to re-run from the start so if there are"
+      echo "  currently jobs which have been running a long time you may wish to delay"
+      echo "  upgrading."
+      echo
+      echo "  Choose 'n' below to decline the update, or 'Y' to proceed."
+      echo
+    apt-mark unhold "$package_to_hold"
+    apt-get upgrade
+  fi

--- a/scripts/install_packages.sh
+++ b/scripts/install_packages.sh
@@ -6,8 +6,17 @@ set -euo pipefail
 set +u
 sed 's/^#.*//' purge-packages.txt | xargs apt-get purge -y
 apt-get update
-apt-get upgrade -y
 sed 's/^#.*//' core-packages.txt | xargs apt-get install --no-install-recommends -y
 sed 's/^#.*//' packages.txt | xargs apt-get install --no-install-recommends -y
 apt-get autoremove -y
 set -u
+
+if apt list --upgradable 2>/dev/null | grep -q "upgradable from"; then
+  echo "=============================== APT UPDATES AVAILABLE ==============================="
+  echo
+  echo "Newer versions of apt packages are available; you should run:"
+  echo
+  echo "    just apt-upgrade"
+  echo
+  echo "====================================================================================="
+fi

--- a/tests/backends/test.sh
+++ b/tests/backends/test.sh
@@ -78,3 +78,7 @@ systemctl status --no-pager collector || { journalctl -u collector; exit 1; }
 
 # run airlock tests
 ./tests/check-airlock.sh
+
+# Test the upgrade command completes without error (we have to use Y to accept
+# the upgrade because declining causes a non-zero exit)
+echo 'Y' | just apt-upgrade


### PR DESCRIPTION
Prevent `just manage` from automatically applying apt updates and provide a separate command for doing that. We want to be able to apply configuration changes without inadvertently upgrading packages which we may not be [ready to upgrade][1]. In particular, updates to Docker require a restart of running containers which needs careful scheduling as this can disrupt long-running jobs.

Although regularly applying apt updates is a desirable goal we've decided that splitting this out from the more general `manage` command is the pragmatic decision. See:
https://bennettoxford.slack.com/archives/C069YDR4NCA/p1747918806910709

Closes #280

[1]: https://bennettoxford.slack.com/archives/C069YDR4NCA/p1748617349409839?thread_ts=1748610596.289879&cid=C069YDR4NCA