### PR TITLE
Stop running temporary dev image on test backend

### DIFF
--- a/services/jobrunner/install.sh
+++ b/services/jobrunner/install.sh
@@ -24,11 +24,6 @@ cp $SRC_DIR/bin/* ~opensafely/bin/
 # setup some automated config for docker group id
 echo "DOCKER_HOST_GROUPID=$(getent group docker | awk -F: '{print $3}')" > $DIR/.env
 
-# run the dev container on the test-backend
-if [ "$BACKEND" = "test" ]; then
-  echo "JOB_RUNNER_DOCKER_IMAGE=job-runner-split" >> $DIR/.env
-fi
-
 chown -R opensafely:opensafely $DIR
 
 # TODO: this should probably live somewhere else, as its more than just a jobrunner thing


### PR DESCRIPTION
This reflects a change already made on the test server. Now that the agent/controller split is in production we want to be running the production image here.