### PR TITLE
Reduce journalctl log noise

### DIFF
--- a/services/airlock/justfile
+++ b/services/airlock/justfile
@@ -20,7 +20,7 @@ restart *args:
 
 # show airlock logs
 logs *args:
-    sudo journalctl -t airlock {{ args }}
+    sudo journalctl -t airlock --output=cat {{ args }}
 
 # update to the certificate for airlock from backends.opensafely.org
 update-certs:

--- a/services/jobrunner/justfile
+++ b/services/jobrunner/justfile
@@ -40,11 +40,11 @@ cli command *ARGS:
 
 # show logs
 logs *args:
-    sudo journalctl -t agent {{ args }}
+    sudo journalctl -t agent --output=cat {{ args }}
 
 # show logs for a specific job_id
 logs-id job_id:
-    sudo journalctl -t agent -g {{ job_id }}
+    sudo journalctl -t agent --output=cat -g {{ job_id }}
 
 # list all currently running jobs
 jobs-ls:


### PR DESCRIPTION
By default, journalctl output prefixes log lines with timestamps,
hostname, and service. Its intended for whole system or multisystem
logs.

In our just wrapped use of journalctl, the host is alwasy the same and
thus irrelevant, we've already filterd on the service name by tag. We
also print the timestamps ourselves, so that's just noise.

Removing all this by just echoing the raw logs removes this noise and
thus improves log readability.
