### PR TITLE
Comment out accidentally re-added filesystem aggregation

### DIFF
--- a/services/collector/collector.yaml
+++ b/services/collector/collector.yaml
@@ -329,33 +329,34 @@ processors:
           - action: aggregate_labels
             aggregation_type: sum
             label_set: []
-      - include: system.filesystem.usage
-        experimental_match_labels:
-          state: free
-        action: insert
-        new_name: system.filesystem.usage.free
-        operations:
-          - action: aggregate_labels
-            aggregation_type: sum
-            label_set: []
-      - include: system.filesystem.usage
-        experimental_match_labels:
-          state: reserved
-        action: insert
-        new_name: system.filesystem.usage.reserved
-        operations:
-          - action: aggregate_labels
-            aggregation_type: sum
-            label_set: []
-      - include: system.filesystem.usage
-        experimental_match_labels:
-          state: used
-        action: insert
-        new_name: system.filesystem.usage.used
-        operations:
-          - action: aggregate_labels
-            aggregation_type: sum
-            label_set: []
+      # Note: we do not want aggregated filesystem data
+      #- include: system.filesystem.usage
+      #  experimental_match_labels:
+      #    state: free
+      #  action: insert
+      #  new_name: system.filesystem.usage.free
+      #  operations:
+      #    - action: aggregate_labels
+      #      aggregation_type: sum
+      #      label_set: []
+      #- include: system.filesystem.usage
+      #  experimental_match_labels:
+      #    state: reserved
+      #  action: insert
+      #  new_name: system.filesystem.usage.reserved
+      #  operations:
+      #    - action: aggregate_labels
+      #      aggregation_type: sum
+      #      label_set: []
+      #- include: system.filesystem.usage
+      #  experimental_match_labels:
+      #    state: used
+      #  action: insert
+      #  new_name: system.filesystem.usage.used
+      #  operations:
+      #    - action: aggregate_labels
+      #      aggregation_type: sum
+      #     label_set: []
       - include: system.filesystem.inodes.usage
         experimental_match_labels:
           state: free


### PR DESCRIPTION
In #290, when updating the collector config, we accidentally restored
config that we had explicitly deleted in f1e7cac7dcba7db9aa7e5ba5b1384d0f7bd34d29

This comments that same block out, as a reminder that we don't want it.
