### PR TITLE
Bump otel limits

### DIFF
--- a/config/defaults.env
+++ b/config/defaults.env
@@ -33,3 +33,11 @@ DATABASE_ACCESS_NETWORK=jobrunner-db
 
 # RAP Agent
 CONTROLLER_TASK_API_ENDPOINT=https://controller.opensafely.org
+
+
+# OTEL client defaults are very low, honeycomb supports much higher values. We
+# silently lose data if we hit these limits, so bump them.
+OTEL_SPAN_ATTRIBUTE_COUNT_LIMIT=2000        # Honeycomb: 2,000 fields per event
+# this is partiularly useful for formatted SQL queries.
+OTEL_SPAN_ATTRIBUTE_VALUE_LENGTH_LIMIT=65536 # Honeycomb: 64KB per string field
+


### PR DESCRIPTION
The default client limits for attributes per span is 128, and size of attribute value is 1024.

If you hit them, the additional attributes are dropped, and the values are truncated.

Honeycomb supports much higher values, so set them globally to ensure we do not silently lose data.

The large value length is particularly useful for ehrql's preformatted SQL queries.
