### PR TITLE
Add OTEL_SEMCONV_STABILITY_OPT_IN env var to defaults

### DIFF
--- a/config/defaults.env
+++ b/config/defaults.env
@@ -40,4 +40,4 @@ CONTROLLER_TASK_API_ENDPOINT=https://controller.opensafely.org
 OTEL_SPAN_ATTRIBUTE_COUNT_LIMIT=2000        # Honeycomb: 2,000 fields per event
 # this is partiularly useful for formatted SQL queries.
 OTEL_SPAN_ATTRIBUTE_VALUE_LENGTH_LIMIT=65536 # Honeycomb: 64KB per string field
-
+OTEL_SEMCONV_STABILITY_OPT_IN=http


### PR DESCRIPTION
Use the stable http semantic conventions (v1.23.0) https://github.com/open-telemetry/semantic-conventions/tree/v1.23.0/docs/http

See also : https://opentelemetry.io/blog/2023/http-conventions-declared-stable/