### PR TITLE
Update and pin to modern lxd

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -32,7 +32,7 @@ jobs:
     - name: Setup lxd
       uses: canonical/setup-lxd@8c6a87bfb56aa48f3fb9b830baa18562d8bfd4ee # 1
       with:
-        channel: latest/stable
+        channel: 5.21/stable
     - name: Setup just
       uses: extractions/setup-just@f8a3cce218d9f83db3a2ecd90e41ac3de6cdfd9b # 3.1.0
     - name: Checkout
@@ -43,7 +43,10 @@ jobs:
         df -h
         just tests/build
         # delete base ubuntu image as we sometimes run out of diskspace
-        lxc image delete "$(lxc image ls -f csv | grep "ubuntu" | awk -F, '{print $2}')"
+        base_image="$(lxc image ls -f csv | awk -F, '$1 ~ /ubuntu/ { print $2; exit }')"
+        if [ -n "$base_image" ]; then
+          lxc image delete "$base_image"
+        fi
         sudo lxc image ls
         df -h
     - name: Run tests

--- a/DEVELOPERS.md
+++ b/DEVELOPERS.md
@@ -26,36 +26,62 @@ Directory layout:
 
 ## Testing
 
-To run tests, we use LXD to provide and isolate VM-like environment. 
+To run tests, we use LXD to provide and isolated VM-like environment. 
+
+There are specific reasons we use LXD:
+ - provides a VM like container on standard images, with systemd, sshd, etc, unlike docker.
+ - can run nested docker containers easily
+ - works in Github CI where we cannot have nested VMs
 
 ### Configuring LXD
 
-You will need to have LXD installed and configured, and `shiftfs` enabled. Currently,
-this probably only works on Ubuntu. Try their [First steps with LXD](https://documentation.ubuntu.com/lxd/en/latest/tutorial/first_steps/). 
+You will need to have LXD installed and configured. This currently assumes an
+Ubuntu host. Try their [First steps with LXD](https://documentation.ubuntu.com/lxd/en/latest/tutorial/first_steps/).
 
 Don't forget to [configure your firewall](https://documentation.ubuntu.com/lxd/en/latest/howto/network_bridge_firewalld/) appropriately.
 
 #### LXD Quickstart for ubuntu:
 
 ```
-snap install lxd --classic
-sudo snap set lxd shiftfs.enable=true
+sudo snap install lxd --channel=5.21/stable
+sudo usermod -aG lxd "$USER"
+newgrp lxd
 sudo lxd init --auto
+```
+
+This default setup is fine for most developers, if a bit slow
+
+
+If you have zfs on your host, and you want faster lxd performance you can instead do:
+
+```
+sudo lxd init --auto --storage-backend=zfs
+```
+
+If you get errors about missing tools, you maybe on more a recent HWE kernel, and need a more recent lxd:
+
+```
+sudo snap refresh lxd --channel=6/stable
 ```
 
 #### Firewall setup for LXD
 
-To configure ufw to allow network traffic to/from LXD instances, you'll need the name of your internet interface.
-
-You're looking for the thing that comes after `dev` in the output of `ip route show default`, eg `eth0` or `wlp0s20f3`.
-
-Then as root:
+To configure ufw to allow network traffic to/from LXD instances, run:
 
 ```
-ufw allow in on lxdbr0
-ufw allow out on lxdbr0
-ufw route allow in on lxdbr0 out on <interface-name>
-ufw reload
+sudo ufw allow in on lxdbr0
+sudo ufw route allow in on lxdbr0
+sudo ufw route allow out on lxdbr0
+```
+
+If you also run Docker on the host, Docker can set the global `FORWARD` policy
+to `DROP`, which breaks network access for LXD instances. The LXD docs
+recommend enabling IPv4 forwarding before Docker starts and making it
+persistent across reboots:
+
+```
+echo "net.ipv4.conf.all.forwarding=1" | sudo tee /etc/sysctl.d/99-forwarding.conf
+sudo systemctl restart systemd-sysctl
 ```
 
 ### Running tests
@@ -72,3 +98,6 @@ If you specify DEBUG=1, then you will be dropped into a shell inside the docker
 container after the tests has run, e.g. 
 
     DEBUG=1 just tests/run_test tests/$TEST 
+
+Note: `DEBUG=1` uses a shifted bind mount for a nicer edit/debug cycle. Normal
+test runs do not rely on that mount path.

--- a/tests/run-in-lxd.sh
+++ b/tests/run-in-lxd.sh
@@ -26,13 +26,13 @@ fi
 
 
 clean_name="$(basename "$SCRIPT")"
-CONTAINER="backend-server-${clean_name%.*}"
+CONTAINER="backend-server-run-${clean_name%.*}"
 
 # this function is used in a trap, so ignore SC2317
 # shellcheck disable=SC2317
 cleanup() {
     # ephemeral container deleted when stopped
-    lxc stop "$CONTAINER"
+    lxc stop "$CONTAINER" || true
 }
 
 trap cleanup EXIT INT


### PR DESCRIPTION
Pin to the LTS release 5.21, both locally and CI

Update outdated instructions
 - no need for shiftfs config
 - simpler firewall rules

Fix a minor bug with container naming,
