### PR TITLE
Replace job-server domain in  list of hosts

### DIFF
--- a/etc/opensafely/hosts
+++ b/etc/opensafely/hosts
@@ -1,2 +1,2 @@
 # Hardcoded values for our core DNS names for all backends
-157.245.31.108 jobs.opensafely.org github-proxy.opensafely.org docker-proxy.opensafely.org collector.opensafely.org backends.opensafely.org controller.opensafely.org
+157.245.31.108 jobs.opensafely.org release.opensafely.org github-proxy.opensafely.org docker-proxy.opensafely.org collector.opensafely.org backends.opensafely.org controller.opensafely.org

--- a/scripts/install_packages.sh
+++ b/scripts/install_packages.sh
@@ -6,8 +6,8 @@ set -euo pipefail
 set +u
 sed 's/^#.*//' purge-packages.txt | xargs apt-get purge -y
 apt-get update
-sed 's/^#.*//' core-packages.txt | xargs apt-get install --no-install-recommends -y
-sed 's/^#.*//' packages.txt | xargs apt-get install --no-install-recommends -y
+sed 's/^#.*//' core-packages.txt | xargs apt-get install --no-install-recommends --no-upgrade -y
+sed 's/^#.*//' packages.txt | xargs apt-get install --no-install-recommends --no-upgrade -y
 apt-get autoremove -y
 set -u
 


### PR DESCRIPTION
Job-server is being moved behind clourflare and backends will use this dedicated domain to access it.