### PR TITLE
Use `apt` instead of `apt-get` for `just apt-upgrade`

### DIFF
--- a/justfile
+++ b/justfile
@@ -93,10 +93,10 @@ apt-upgrade:
 
   package_to_hold='docker.io'
 
-  apt-get update
+  apt update
   apt-mark hold "$package_to_hold"
-  apt-get upgrade -y
-  apt-get autoremove -y
+  apt upgrade -y
+  apt autoremove -y
 
   if apt list --upgradable "$package_to_hold" 2>/dev/null | grep -qF "$package_to_hold"; then
       echo
@@ -113,5 +113,5 @@ apt-upgrade:
       echo "  Choose 'n' below to decline the update, or 'Y' to proceed."
       echo
     apt-mark unhold "$package_to_hold"
-    apt-get upgrade
+    apt upgrade
   fi


### PR DESCRIPTION
This won't refuse to install new packages if required for an upgrade, unlike `apt-get upgrade`. We could use `apt-get full-upgrade` but `apt` feels like a better fit for an interactive command in any case.

See related Slack thread:
https://bennettoxford.slack.com/archives/C069YDR4NCA/p1776782848666299?thread_ts=1776763462.212979&cid=C069YDR4NCA