### PR TITLE
Remove `logging` from configured otel exporters

### DIFF
--- a/services/collector/collector.yaml
+++ b/services/collector/collector.yaml
@@ -731,7 +731,6 @@ service:
         - resourcedetection
         - batch
       exporters:
-        - logging
         - otlphttp/metrics
     traces:
       receivers:
@@ -741,5 +740,4 @@ service:
         - resourcedetection
         - batch
       exporters:
-        - logging
         - otlphttp/traces


### PR DESCRIPTION
This had the effect that every otel metric/trace ended up in the systemd journal, which significantly bloated our logs and reduced our effective retention period.

Having this data logged would have made sense when we were first configuring and testing the collector, but is not helpful now.

See Slack discussion at:
https://bennettoxford.slack.com/archives/C069YDR4NCA/p1778171836696039