### PR TITLE
Remove INCLUDE_T1OO_DATABASE_URL from config template

### DIFF
--- a/config/secrets-template.env
+++ b/config/secrets-template.env
@@ -16,11 +16,8 @@ JOB_SERVER_TOKEN=
 # so the token can be regenerated.
 PRIVATE_REPO_ACCESS_TOKEN=
 
-# Credentials for accessing a database with T1OO patients excluded
+# Credentials for accessing the database
 DEFAULT_DATABASE_URL=
-
-# Credentials for accessing a database with T1OO patients included
-INCLUDE_T1OO_DATABASE_URL=
 
 # Space separated list of IP addresses to which database jobs need access.
 # Note, this will be used as a `--destination` argument in an iptables rule and


### PR DESCRIPTION
The database url is no longer used to control t1oo permissions, and all jobs will now use the DEFAULT_DATABASE_URL

Part 5 of https://github.com/opensafely-core/ehrql/issues/2801