### PR TITLE
Use simpler and safer method of updating held packages

### DIFF
--- a/justfile
+++ b/justfile
@@ -110,8 +110,14 @@ apt-upgrade:
     echo "  currently jobs which have been running a long time you may wish to delay"
     echo "  upgrading."
     echo
-    echo "  Choose 'n' below to decline the update, or 'Y' to proceed."
+    echo "  Choose 'n' below to decline the update, or 'y' to proceed."
     echo
-    apt-mark unhold "$package_to_hold"
-    apt upgrade
+
+    read -p "Kill all running containers and upgrade Docker? [y/N] " -r
+    if [[ ! "$REPLY" =~ ^[Yy]$ ]]
+    then
+      exit 0
+    fi
+
+    apt install --only-upgrade --allow-change-held-packages "$package_to_hold"
   fi

--- a/justfile
+++ b/justfile
@@ -99,19 +99,19 @@ apt-upgrade:
   apt autoremove -y
 
   if apt list --upgradable "$package_to_hold" 2>/dev/null | grep -qF "$package_to_hold"; then
-      echo
-      echo "  => WARNING <="
-      echo
-      echo "  The '$package_to_hold' package has an update pending. This usually requires"
-      echo "  a restart of all running Docker containers. To avoid disruption to user"
-      echo "  jobs you should first run a prepare_for_reboot on the controller."
-      echo
-      echo "  Note that jobs will have to re-run from the start so if there are"
-      echo "  currently jobs which have been running a long time you may wish to delay"
-      echo "  upgrading."
-      echo
-      echo "  Choose 'n' below to decline the update, or 'Y' to proceed."
-      echo
+    echo
+    echo "  => WARNING <="
+    echo
+    echo "  The '$package_to_hold' package has an update pending. This usually requires"
+    echo "  a restart of all running Docker containers. To avoid disruption to user"
+    echo "  jobs you should first run a prepare_for_reboot on the controller."
+    echo
+    echo "  Note that jobs will have to re-run from the start so if there are"
+    echo "  currently jobs which have been running a long time you may wish to delay"
+    echo "  upgrading."
+    echo
+    echo "  Choose 'n' below to decline the update, or 'Y' to proceed."
+    echo
     apt-mark unhold "$package_to_hold"
     apt upgrade
   fi


### PR DESCRIPTION
The previous approach left the package in an un-held state until the next time the `just apt-upgrade` command was run again. This meant that it could get updated during the automatic overnight updates, causing unplanned disruption to user jobs.

Closes #335