### PR TITLE
Fix GitHub Actions vulnerabilities

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -5,3 +5,5 @@ updates:
     directory: "/"
     schedule:
       interval: "monthly"
+    cooldown:
+      default-days: 7

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -20,7 +20,9 @@ jobs:
       with:
         install-just: true
     - name: Checkout
-      uses: actions/checkout@v6
+      uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
+      with:
+        persist-credentials: false
     - name: Run lint
       run: just tests/lint
   tests:
@@ -32,7 +34,7 @@ jobs:
     runs-on: ubuntu-22.04
     steps:
     - name: Setup lxd
-      uses: canonical/setup-lxd@8c6a87bfb56aa48f3fb9b830baa18562d8bfd4ee # 1
+      uses: canonical/setup-lxd@8c6a87bfb56aa48f3fb9b830baa18562d8bfd4ee # v1
       with:
         channel: 5.21/stable
     - name: Setup just
@@ -40,7 +42,9 @@ jobs:
       with:
         install-just: true
     - name: Checkout
-      uses: actions/checkout@v6
+      uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
+      with:
+        persist-credentials: false
     - name: Prepare test image
       run: |
         # some debugging info in case stuff fails


### PR DESCRIPTION
Chained PR following #338.

Part of https://github.com/opensafely-core/security/issues/46, https://github.com/opensafely-core/security/issues/47

Based on automated changes from running `zizmor --fix=all .`.

Verified that all the complaints upon running zizmor are not listed in the tickets.

