### PR TITLE
Split out `mkdir` step from `tar` command

### DIFF
--- a/tests/run-in-lxd.sh
+++ b/tests/run-in-lxd.sh
@@ -66,7 +66,8 @@ wait_for_cloud_init "$CONTAINER"
 if test -z "${DEBUG:-}"; then
     # if we're not in debug mode, just copy files. This does not require shiftfs,
     # so works in GHA and on more systems.
-    tar c . | lxc exec "$CONTAINER" -- tar x --one-top-level=$BACKEND_SERVER_DIR
+    lxc exec "$CONTAINER" -- mkdir -p "$BACKEND_SERVER_DIR"
+    tar c . | lxc exec "$CONTAINER" -- tar x -C "$BACKEND_SERVER_DIR"
     DEBIAN_FRONTEND=noninteractive
 else
     # in debug mode, it is useful to have the project mounted in the the


### PR DESCRIPTION
Our tests are failing in CI with an error saying:
```
    tar: <dir>: Cannot mkdir: Invalid cross-device link
```

at the step where we pipe a tar stream into the container and extract it with `tar x --one-top-level=$DIR`, which creates $DIR and extracts into it in one operation.

Splitting this into two steps:
  * `mkdir -p $DIR` inside the container, then
  * `tar x -C $DIR`

makes the error go away.

This issue was potentially related to some changes in `tar` related to the `--one-top-level` behaviour  - see this mailing list [thread](https://www.mail-archive.com/bug-tar@gnu.org/msg06572.html),