### PR TITLE
Fix GitHub Actions vulnerabilities

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -5,3 +5,5 @@ updates:
     directory: "/"
     schedule:
       interval: "monthly"
+    cooldown:
+      default-days: 7

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -18,7 +18,9 @@ jobs:
       run: sudo apt-get install -y shellcheck
     - uses: extractions/setup-just@f8a3cce218d9f83db3a2ecd90e41ac3de6cdfd9b # 3.1.0
     - name: Checkout
-      uses: actions/checkout@v7
+      uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+      with:
+        persist-credentials: false
     - name: Run lint
       run: just tests/lint
   tests:
@@ -30,13 +32,15 @@ jobs:
     runs-on: ubuntu-22.04
     steps:
     - name: Setup lxd
-      uses: canonical/setup-lxd@8c6a87bfb56aa48f3fb9b830baa18562d8bfd4ee # 1
+      uses: canonical/setup-lxd@8c6a87bfb56aa48f3fb9b830baa18562d8bfd4ee # v1
       with:
         channel: 5.21/stable
     - name: Setup just
       uses: extractions/setup-just@f8a3cce218d9f83db3a2ecd90e41ac3de6cdfd9b # 3.1.0
     - name: Checkout
-      uses: actions/checkout@v7
+      uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+      with:
+        persist-credentials: false
     - name: Prepare test image
       run: |
         # some debugging info in case stuff fails


### PR DESCRIPTION
The commit in #340 was not merged into `main`. 

In hindsight, #340 should not have been a chained PR as these changes ended up being blocked on a separate change (removing `setup-just`) that was needing review.

Separate out the `zizmor` changes in this PR and propose to merge them first, as I should have done initially.