### PR TITLE
Use setup-action to install `just` for CI tests

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -16,7 +16,9 @@ jobs:
     steps:
     - name: Install lint dependencies
       run: sudo apt-get install -y shellcheck
-    - uses: extractions/setup-just@f8a3cce218d9f83db3a2ecd90e41ac3de6cdfd9b # 3.1.0
+    - uses: "opensafely-core/setup-action@d9171097dd0d37bdb7bed58f701eb03ff317ed17" # v1
+      with:
+        install-just: true
     - name: Checkout
       uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
       with:
@@ -36,7 +38,9 @@ jobs:
       with:
         channel: 5.21/stable
     - name: Setup just
-      uses: extractions/setup-just@f8a3cce218d9f83db3a2ecd90e41ac3de6cdfd9b # 3.1.0
+      uses: "opensafely-core/setup-action@93841f27c28c75bf85b1a0a915e2391a06c6c8a6" # v1
+      with:
+        install-just: true
     - name: Checkout
       uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
       with:


### PR DESCRIPTION
Alternative to #332. Was previously #338 but that PR was accidentally closed (my apologies...).

Our workflow for running tests on CI uses `just` to lint and run tests. At the moment `just` is installed via the third party `setup-just` action. This means that we would have to review dependency updates for `setup-just`, and the `setup-crate` transitive dependency. Using `setup-action` means less work for us.

`setup-action` was used previously but replaced by `setup-just` in 110d167b970354f7aaabadc80c079a4b08379230, as it was suspected that `setup-action` might unnecessarily install Python and cause disk space issues on the runners.

From the GitHub action logs, it doesn't seem like `setup-action` installs Python unless we ask it to, it only installs `just`: https://github.com/opensafely-core/backend-server/actions/runs/26868612560/job/79238036339#logs

We can probably switch back to using `setup-action` and see if we get CI failures related to disk space again - if the errors do come back we can always roll back this change.