### PR TITLE
Update hosts and docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,10 +3,11 @@
 OpenSAFELY backends are deployed on servers inside our partners' secure
 environments. These servers are provisioned and managed by the provider,
 with limited network access. They are designed to run the
-[job-runner](https://github.com/opensafely-core/job-runner) process,
-which polls jobs.opensafely.org for work, and then runs the requested
-actions securely inside docker containers. It also handles the process for
-redaction, review and publication of outputs.
+[RAP agent](https://github.com/opensafely-core/job-runner) process,
+which polls the RAP controller (controller.opensafely.org) for work, and then runs the requested
+actions securely inside docker containers.
+They also run [Airlock](https://github.com/opensafely-core/airlock), which
+handles the process for review and release of outputs.
 
 Due to being deployed in different partner's environments, and us not
 always having full administrative control of that environment, each
@@ -45,11 +46,10 @@ A plain `just` will list other commands available, with help
 ## Base assumptions
 
  * Ubuntu server (22.04 baseline)
- * Internet access to {jobs,docker-proxy,github-proxy}.opensafely.org
- * Internet access to an official ubuntu archive
+ * Internet access to opensafely.org domains (see [system-requirements](system-requirements.md#network-requirements))
  * SSH access for developers to the backend host
  * sudo access on the host in some form
- * Just bash and git needed on the host to bootstrap backend.
+ * Just, bash and git needed on the host to bootstrap backend.
 
 ## Components
 
@@ -63,6 +63,18 @@ Currently in `/srv/high_privacy` and `/srv/medium_privacy`. Files owned by
 Repo: https://github.com/opensafely-core/job-runner
 
 Manages the jobs and their state. Deployed in `/home/opensafely/jobrunner` as a docker-compose managed service
+
+### airlock
+ 
+Repo: https://github.com/opensafely-core/airlock
+
+Manages requests to release output files. Deployed in `/home/opensafely/airlock` as a docker-compose managed service
+
+### collector
+
+See [services/collector](services/collector)
+
+Collects and emits host metrics. Deployed in `/home/opensafely/collector` as a systemd service running the otel binary directly. Sends metrics to the [otel gateway](https://github.com/opensafely-core/sysadmin/tree/main/services/otel-gateway) at collector.opensafely.org.
 
 ## Common goals for all backends
 

--- a/backends/tpp/README.md
+++ b/backends/tpp/README.md
@@ -59,19 +59,15 @@ must SSH in again to actually access it.
  - login to host is via authenticated firewall and RDP, accounts managed by
    TPP.
  - Outgoing internet is restricted to https to our cloudflare IPs
- - TPP maintain a one-way push of medium privacy output files to the
-   Level 4 server.
- - As TPP was early adopter, many users have RDP access to this machine.
- - Goal is to reduce that to just the OpenSAFELY platform team. As such, we are
-   only granting core OpenSAFELY team access to the VM.
+ - Incoming internet access is restricted to the Level 4 server (to allow access to Airlock)
+ - Only limited developers have RDP access to this machine. User who need to view and release output files have access via Airlock on Level 4 only.
 
 
 ### Level 4 Server
 
  - TPP provide a windows VM on the same host.
  - Login is via same firewall, but separate RDP account.
- - Redaction and publishing happens here.
- - Files pushed here from level 3.
+ - Review and release of outputs via Airlock happens here.
 
 ### Implications
 

--- a/backends/tpp/opensafely-tpp.txt
+++ b/backends/tpp/opensafely-tpp.txt
@@ -27,7 +27,3 @@ Network access:
 
  - Port 22 exposed to VM Host, but not externally.
  - egress to *.opensafely.org, as currently for host.
- - New egress needed:
-    - archive.ubuntu.com: 91.189.88.142, 91.189.88.152
-    - security.ubuntu.com: 91.189.88.142, 91.189.88.152, 91.189.91.39, 91.189.91.38
-

--- a/etc/opensafely/hosts
+++ b/etc/opensafely/hosts
@@ -1,2 +1,2 @@
 # Hardcoded values for our core DNS names for all backends
-157.245.31.108 jobs.opensafely.org release.opensafely.org github-proxy.opensafely.org docker-proxy.opensafely.org collector.opensafely.org backends.opensafely.org controller.opensafely.org archive-ubuntu.opensafely.org security-ubuntu.opensafely.org
+157.245.31.108 release.opensafely.org github-proxy.opensafely.org docker-proxy.opensafely.org collector.opensafely.org backends.opensafely.org controller.opensafely.org archive-ubuntu.opensafely.org security-ubuntu.opensafely.org

--- a/playbook.md
+++ b/playbook.md
@@ -35,7 +35,7 @@ This will set up your shell with the correct environment variables.
 /home/opensafely/airlock    # airlock service workdir and configuration
 /home/opensafely/collector  # otel collector service
 
-## jobrunner service
+## jobrunner service (RAP Agent)
 
 The jobrunner is installed in `/home/opensafely/jobrunner`.
 
@@ -285,22 +285,6 @@ For tables within the `OpenCORONATempTables` database:
 
     SELECT COUNT(*) FROM <name of table> (NOLOCK).
 
-
-### Removing a Level 4 file
-
-There are times when these medium privacy outputs may need to be deleted. For
-example, the researcher or output checkers may realise they should have been
-marked as high privacy, or the researcher may no longer need the output and
-want to preserve disk space.
-
-All outputs are put into the `/srv/high_privacy/workspaces/` directory for
-a workspace on the VM.
-
-Outputs that have been marked as having a medium privacy level are then copied
-into the matching `/srv/medium_privacy/workspaces/` directory.
-
-To remove a level 4 file, you can just delete the file from the correct
-`/srv/medium_privacy/workspaces/$WORKSPACE` directory.
 
 ## Start up and Shutdown
 

--- a/system-requirements.md
+++ b/system-requirements.md
@@ -15,9 +15,9 @@ The explicit list can be found in [core-packages.txt](core-packages.txt).
 
 ## Services
 
-The are currently three services, installed and run by the `opensafely` user
+The are currently four services, installed and run by the `opensafely` user
 
-### jobrunner
+### RAP agent
 
 This lives in ~opensafely/jobrunner.
 
@@ -28,23 +28,35 @@ images used to run them, via the OpenSAFELY proxies (see below).
 
 ### collector
 
-This service lives in ~opensafely/collector
+This service lives in ~opensafely/collector.
 
-It collects and emits host metrics
+It collects and emits host metrics.
+
+### Airlock app and daily jobs
+
+These services live in ~opensafely/airlock.
+
+The Airlock service runs the Airlock web app, which listens on port 80, and is
+accessible only from Level 4.
+
+The Airlock runjobs service runs the [daily Airlock jobs](https://github.com/opensafely-core/airlock/tree/36aaa7c658e84ea50d4e8acbf07d6095d15e9f63/airlock/jobs).
 
 
 ## Network Requirements
 
-An OpenSAFELY backend requires egress to 157.245.31.108 on port 443.
+An OpenSAFELY backend requires egress to 157.245.31.108 (dokku4) on port 443.
 
 If routing via a HTTPS proxy, then the following domains are required (all accessible via that IP):
 
-    jobs.opensafely.org
     docker-proxy.opensafely.org
     github-proxy.opensafely.org
+    release.opensafely.org
+    controller.opensafely.org
+    collector.opensafely.org
+    backends.opensafely.org
+    archive-ubuntu.opensafely.org
+    security-ubuntu.opensafely.org
 
-
-Note: the 2 proxy domains proxy HTTPS requests through to `ghcr.io` and
+Note: the docker and github proxy domains proxy HTTPS requests through to `ghcr.io` and
 `github.com` respectively. They restrict access to the OpenSAFELY and
 opensafely-core Github organisations only, and are read only.
-


### PR DESCRIPTION
- Remove jobs.opensafely.org from the list of hardcoded DNS names - we now proxy release.opensafely.org to it 
- Update out of date docs (I've mostly limited this to updating things that are actually incorrect in terms of the current state of affairs, rather than adding/improving things)
- I've removed the instructions for "Removing a Level 4 file", since this isn't really compatible with Airlock (see [slack](https://bennettoxford.slack.com/archives/C069YDR4NCA/p1787219584775039)); we may want to add something about it in future if it's still a thing we might need to do, but if so, it probably belongs in the team manual as a tech-support entry.
