### PR TITLE
Don't give usable default value in secret template

### DIFF
--- a/config/secrets-template.env
+++ b/config/secrets-template.env
@@ -37,4 +37,4 @@ OTEL_EXPORTER_OTLP_HEADERS="Authorization=..."
 
 # airlock
 AIRLOCK_API_TOKEN=${JOB_SERVER_TOKEN}
-DJANGO_SECRET_KEY=this-is-a-bad-secret-key-please-never-use-in-prod
+DJANGO_SECRET_KEY=

--- a/tests/config.env
+++ b/tests/config.env
@@ -3,6 +3,7 @@
 JOB_SERVER_TOKEN="test-test-test-test-test-test-test-test"
 TEST_JOB_SERVER_TOKEN="test-test-test-test-test-test-test-test"
 AIRLOCK_API_TOKEN="test-test-test-test-test-test-test-test"
+DJANGO_SECRET_KEY="test-test-test-test-test-test-test-test"
 TEST=true
 # fake controller provided for testing, uses docker bridge as is meant to be
 # used by agent running in docker-container


### PR DESCRIPTION
The default value for DJANGO_SECRET_KEY has been replaced in 02_secrets.env in the TPP secure environment.  As such, this does not fix any live security hole.

However, given the tiny risk of an operator not updating it in a new deployment, we should give it a value that Django will not accept.